### PR TITLE
typo docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
- aservices:
+ services:
   # ka9q-radio backend (radiod) - SDR receiver daemon
   ka9q-radio:
     build:


### PR DESCRIPTION
There is an "a" at the beginning of the file