### PR TITLE
Add opt-in remote-tune API (postMessage bridge to radioAPI)

### DIFF
--- a/config.go
+++ b/config.go
@@ -252,6 +252,13 @@ type RadiodConfig struct {
 }
 
 // ServerConfig contains web server settings
+// RemoteControlConfig enables an opt-in postMessage API that lets allowlisted
+// opener windows retune the current session in place (see static/remote-control.js).
+type RemoteControlConfig struct {
+	Enabled        bool     `yaml:"enabled"`
+	AllowedOrigins []string `yaml:"allowed_origins"`
+}
+
 type ServerConfig struct {
 	Listen                          string               `yaml:"listen"`
 	MaxSessions                     int                  `yaml:"max_sessions"`
@@ -290,6 +297,7 @@ type ServerConfig struct {
 	CustomHeadHTML                  string               `yaml:"custom_head_html"`                    // Custom HTML to inject into <head> section of index.html (for analytics, ads, meta tags, etc.)
 	CustomBodyHTML                  string               `yaml:"custom_body_html"`                    // Custom HTML to inject before </body> in index.html (for visible banners, DOM-dependent scripts, ad unit divs, etc.)
 	CustomAdsTxt                    string               `yaml:"custom_ads_txt"`                      // Custom content for /ads.txt endpoint (for Google AdSense verification)
+	RemoteControl                   RemoteControlConfig  `yaml:"remote_control"`                      // Opt-in postMessage remote-tune API (static/remote-control.js)
 	EnabledWidgets                  []string             `yaml:"enabled_widgets"`                     // Widget UUIDs from the collector to inject (sandboxed iframes) after custom_body_html (max 10)
 	timeoutBypassNets               []*net.IPNet         // Parsed CIDR networks (internal use)
 	trustedProxyNets                []*net.IPNet         // Parsed CIDR networks for trusted proxies (internal use)

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -466,6 +466,15 @@ server:
   #
   custom_head_html: ""
 
+  # Remote-tune API (opt-in). Lets allowlisted opener windows (e.g. a companion
+  # panadapter/pointer app) retune THIS session in place via window.postMessage —
+  # no page reload, so the audio-start gate is not re-prompted. Drives only the
+  # current tab's window.radioAPI; does not affect the server-side session model.
+  # See static/remote-control.js. Only the listed origins may control the session.
+  remote_control:
+    enabled: false
+    allowed_origins: []   # e.g. ["https://omnisdr.example"]
+
   # Custom HTML injection before </body> in index.html
   # Use this for visible content that needs the DOM: banners, popups, Google Ads display unit <div>s,
   # or any script that calls document.getElementById / document.body.appendChild.

--- a/main.go
+++ b/main.go
@@ -2927,14 +2927,22 @@ func handleConnectionCheck(w http.ResponseWriter, r *http.Request, sessions *Ses
 
 // handleIndexPage serves the index.html template with custom HTML injection
 func handleIndexPage(w http.ResponseWriter, r *http.Request, config *Config, wm *WidgetManager) {
+	rcOrigins, _ := json.Marshal(config.Server.RemoteControl.AllowedOrigins)
+	if len(rcOrigins) == 0 || string(rcOrigins) == "null" {
+		rcOrigins = []byte("[]")
+	}
 	data := struct {
-		CustomHeadHTML template.HTML
-		CustomBodyHTML template.HTML
-		WidgetsHTML    template.HTML
+		CustomHeadHTML       template.HTML
+		CustomBodyHTML       template.HTML
+		WidgetsHTML          template.HTML
+		RemoteControlEnabled bool
+		RemoteControlOrigins template.JS
 	}{
-		CustomHeadHTML: template.HTML(config.Server.CustomHeadHTML),
-		CustomBodyHTML: template.HTML(config.Server.CustomBodyHTML),
-		WidgetsHTML:    wm.AssembleHTML(config.Server.EnabledWidgets),
+		CustomHeadHTML:       template.HTML(config.Server.CustomHeadHTML),
+		CustomBodyHTML:       template.HTML(config.Server.CustomBodyHTML),
+		WidgetsHTML:          wm.AssembleHTML(config.Server.EnabledWidgets),
+		RemoteControlEnabled: config.Server.RemoteControl.Enabled,
+		RemoteControlOrigins: template.JS(rcOrigins),
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/static/index.html
+++ b/static/index.html
@@ -1565,6 +1565,12 @@
     <script type="module" src="local-bookmarks-ui.js"></script>
     
     <script type="module" src="app.js"></script>
+    {{if .RemoteControlEnabled}}
+    <!-- Remote-tune API bridge (opt-in: server remote_control.enabled). Lets allowlisted
+         opener windows retune this session in place via postMessage. -->
+    <script>window.__ubersdrRemoteControl = { enabled: true, allowedOrigins: {{.RemoteControlOrigins}} };</script>
+    <script src="remote-control.js"></script>
+    {{end}}
 
     <!-- RM Noise AI Denoising Modal -->
     <div id="rmnoise-modal" class="rmnoise-modal-overlay" style="display:none;">

--- a/static/remote-control.js
+++ b/static/remote-control.js
@@ -1,0 +1,57 @@
+/* UberSDR remote-tune API bridge.
+ * Opt-in via server config (remote_control.enabled). Lets an allowlisted opener window
+ * retune THIS session in place via window.postMessage — no reload, so the audio-start
+ * gate is not re-prompted, and the audio context survives. It only drives the current
+ * tab's window.radioAPI, so it does not touch the server-side session model.
+ *
+ * Protocol (versioned, namespaced __ubersdr_rc:1):
+ *   controller -> us : {type:"tune", freqHz, mode?} | {type:"ping"}
+ *   us -> opener     : {type:"ready"} | {type:"tuned", freqHz, mode, ok} | {type:"frequency_changed", freqHz, mode}
+ */
+(function () {
+  "use strict";
+  var cfg = window.__ubersdrRemoteControl || { enabled: false, allowedOrigins: [] };
+  if (!cfg.enabled) return;
+  var V = 1;
+  var ALLOWED = Array.isArray(cfg.allowedOrigins) ? cfg.allowedOrigins : [];
+  function allowed(o) { return ALLOWED.indexOf(o) !== -1; }
+  function api() { return window.radioAPI; }
+
+  function doTune(freqHz, mode) {
+    try {
+      if (mode && api() && api().setMode) api().setMode(mode);
+      if (api() && api().setFrequency) api().setFrequency(freqHz);
+      else if (typeof window.setfreq === "function") window.setfreq(freqHz);
+      return true;
+    } catch (e) { return false; }
+  }
+
+  window.addEventListener("message", function (e) {
+    var m = e.data;
+    if (!m || m.__ubersdr_rc !== V || !allowed(e.origin)) return;
+    if (m.type === "ping") {
+      if (e.source) e.source.postMessage({ __ubersdr_rc: V, type: "ready" }, e.origin);
+    } else if (m.type === "tune") {
+      if (typeof m.freqHz === "number" && m.freqHz >= 10000 && m.freqHz <= 30000000) {
+        var ok = doTune(m.freqHz, m.mode);
+        if (e.source) e.source.postMessage({ __ubersdr_rc: V, type: "tuned", freqHz: m.freqHz, mode: m.mode || null, ok: ok }, e.origin);
+      }
+    }
+  });
+
+  var tries = 0;
+  var timer = setInterval(function () {
+    tries++;
+    if (api() && api().on) {
+      clearInterval(timer);
+      try {
+        api().on("frequency_changed", function (d) {
+          var hz = d && (d.frequency != null ? d.frequency : d.freqHz);
+          var mode = api().getMode ? api().getMode() : null;
+          if (window.opener) ALLOWED.forEach(function (o) { try { window.opener.postMessage({ __ubersdr_rc: V, type: "frequency_changed", freqHz: hz, mode: mode }, o); } catch (_) {} });
+        });
+      } catch (_) {}
+      if (window.opener) ALLOWED.forEach(function (o) { try { window.opener.postMessage({ __ubersdr_rc: V, type: "ready" }, o); } catch (_) {} });
+    } else if (tries > 120) { clearInterval(timer); }
+  }, 500);
+})();


### PR DESCRIPTION
## Summary
Adds an **opt-in** remote-tune API so an **allowlisted opener window** (e.g. a companion
multi-band spectrum "pointer" app) can retune the **current, already-started** session
**in place** via `window.postMessage` — instead of reopening the page with `?freq=`, which
reloads the tab, re-triggers the "Click to Start" audio-gesture gate, and tears down the
audio context.

It builds entirely on existing hooks (`window.radioAPI.setFrequency/setMode/on`, with the
`window.setfreq` fallback) and **does not touch the server-side session model** — it only
drives the current tab's `radioAPI`. The audio-start gesture is unchanged (still once per tab).

## Changes
- `config.go` — new `server.remote_control { enabled, allowed_origins }` (default **off**).
- `main.go` (`handleIndexPage`) — marshals the allowlist and passes `RemoteControlEnabled`
  + `RemoteControlOrigins` into the index template.
- `static/index.html` — when enabled, injects `window.__ubersdrRemoteControl` and loads
  `remote-control.js` after `app.js`.
- `static/remote-control.js` — new gated postMessage bridge.
- `config/config.yaml.example` — documents the `remote_control` block.

## Config
```yaml
server:
  remote_control:
    enabled: false
    allowed_origins: []   # e.g. ["https://omnisdr.example"]
```

## Protocol (versioned, namespaced `__ubersdr_rc: 1`)
- controller → us: `{type:"tune", freqHz, mode?}`, `{type:"ping"}`
- us → opener: `{type:"ready"}`, `{type:"tuned", freqHz, mode, ok}`, `{type:"frequency_changed", freqHz, mode}`

## Security
Opt-in (default off); exact-origin allowlist (no wildcards); validates message version,
shape, and freq range (10 kHz–30 MHz); whitelisted modes via `radioAPI`; controls only the
current tab. No `eval`/dynamic dispatch.

## Testing
The JS bridge has been verified **live** on a real deployment (injected via the existing
`custom_head_html` hook): in-place retune from an allowlisted opener works, and
`frequency_changed` reaches the opener so its marker follows manual retunes. This PR is the
source-integrated form of that bridge. Note: please run it through CI / `go build` — it was
prepared on a box without a Go toolchain, though the change is small and standard.
