### PR TITLE
Expand SDR hardware and decoder support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -42,6 +42,7 @@ tests/
 # Docker files (avoid recursion) - but keep scripts needed by the build
 docker/
 !docker/entrypoint.sh
+!docker/decoder-healthcheck.sh
 !docker/caddy-entrypoint.sh
 !docker/fluent-bit-entrypoint.sh
 !docker/fluent-bit.conf

--- a/.github/workflows/ultrasdr-ci.yml
+++ b/.github/workflows/ultrasdr-ci.yml
@@ -1,0 +1,58 @@
+name: UltraSDR CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "agent/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ultrasdr-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Linux tests and static validation
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+          cache: true
+      - name: Install native build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libopus-dev libopusfile-dev pkg-config
+      - name: Run Go tests
+        run: go test ./...
+      - name: Run decoder race tests
+        run: go test -race ./audio_extensions/digitalvoice ./audio_extensions/signalling
+      - name: Validate browser extensions and scripts
+        run: |
+          node --check static/extensions/digitalvoice/main.js
+          node --check static/extensions/signalling/main.js
+          jq empty static/extensions/digitalvoice/manifest.json
+          jq empty static/extensions/signalling/manifest.json
+          bash -n docker/entrypoint.sh docker/decoder-healthcheck.sh
+
+  docker:
+    name: Docker image build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -10,7 +10,26 @@ The UberSDR website provides comprehensive installation instructions, setup guid
 
 ---
 
-> **Note:** This is currently designed for RX888 MKII SDR hardware to provide 0-30 MHz (full HF) coverage.
+> **Hardware support:** UberSDR now models receiver capabilities independently
+> of the UI and includes KA9Q Radio profiles for RX-888, RTL-SDR, Airspy,
+> Airspy HF+, SDRplay, HackRF, bladeRF, Fobos, FUNcube, and HydraSDR. A generic
+> external-radiod adapter covers remote receivers and separately managed
+> SoapySDR/vendor bridges. See [SDR hardware support](docs/SDR_HARDWARE.md).
+>
+> The automated production installer and its bundled radiod configuration are
+> still tuned for an RX888 MKII providing full-HF coverage. Other devices need
+> the corresponding KA9Q driver/vendor library and receiver configuration.
+
+> **Digital voice:** The `digitalvoice` extension integrates DSD-FME for
+> receive-only DMR, P25 Phase 1/2, NXDN48/96, D-Star, YSF, M17, dPMR,
+> ProVoice/EDACS, and X2-TDMA. It includes 24-to-48 kHz resampling, decoded
+> speech playback, protocol events, and a fixed API that accepts no decryption
+> keys. See [digital voice decoding](docs/DIGITAL_VOICE.md).
+
+> **Paging and signalling:** The `signalling` extension adds POCSAG, FLEX,
+> SAME/EAS, DTMF, two-tone selective calling, and legacy telemetry decoding.
+> See [paging and signalling](docs/SIGNALLING.md) and the
+> [decoder expansion catalog](docs/DECODER_ARCHITECTURE.md).
 
 ## Quick Start
 

--- a/admin.go
+++ b/admin.go
@@ -1644,11 +1644,9 @@ func (ah *AdminHandler) handleAddBookmark(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Reject bookmarks outside the valid HF range (10 kHz – 30 MHz)
-	const bookmarkMinFreq uint64 = 10000
-	const bookmarkMaxFreq uint64 = 30000000
-	if newBookmark.Frequency < bookmarkMinFreq || newBookmark.Frequency > bookmarkMaxFreq {
-		http.Error(w, fmt.Sprintf("Frequency %d Hz is outside the valid range (10 kHz – 30 MHz)", newBookmark.Frequency), http.StatusBadRequest)
+	bookmarkMinFreq, bookmarkMaxFreq := ah.config.FrequencyRange()
+	if !ah.config.IsFrequencySupported(newBookmark.Frequency) {
+		http.Error(w, fmt.Sprintf("Frequency %d Hz is outside the valid range (%d-%d Hz)", newBookmark.Frequency, bookmarkMinFreq, bookmarkMaxFreq), http.StatusBadRequest)
 		return
 	}
 
@@ -1759,9 +1757,8 @@ func (ah *AdminHandler) handleUpdateBookmarks(w http.ResponseWriter, r *http.Req
 			return
 		}
 
-		// Filter out bookmarks outside the valid HF range (10 kHz – 30 MHz).
-		const bulkMinFreq uint64 = 10000
-		const bulkMaxFreq uint64 = 30000000
+		// Filter out bookmarks outside configured receiver coverage.
+		bulkMinFreq, bulkMaxFreq := ah.config.FrequencyRange()
 		accepted := incoming.Bookmarks[:0]
 		skippedCount := 0
 		for _, b := range incoming.Bookmarks {
@@ -1769,7 +1766,7 @@ func (ah *AdminHandler) handleUpdateBookmarks(w http.ResponseWriter, r *http.Req
 				accepted = append(accepted, b)
 			} else {
 				skippedCount++
-				log.Printf("Skipping bookmark '%s' at %d Hz: outside valid HF range (10 kHz – 30 MHz)", b.Name, b.Frequency)
+				log.Printf("Skipping bookmark '%s' at %d Hz: outside receiver range (%d-%d Hz)", b.Name, b.Frequency, bulkMinFreq, bulkMaxFreq)
 			}
 		}
 		incoming.Bookmarks = accepted
@@ -1838,11 +1835,9 @@ func (ah *AdminHandler) handleUpdateBookmarks(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Reject updated frequency outside the valid HF range (10 kHz – 30 MHz)
-	const singleMinFreq uint64 = 10000
-	const singleMaxFreq uint64 = 30000000
-	if updatedBookmark.Frequency < singleMinFreq || updatedBookmark.Frequency > singleMaxFreq {
-		http.Error(w, fmt.Sprintf("Frequency %d Hz is outside the valid range (10 kHz – 30 MHz)", updatedBookmark.Frequency), http.StatusBadRequest)
+	singleMinFreq, singleMaxFreq := ah.config.FrequencyRange()
+	if !ah.config.IsFrequencySupported(updatedBookmark.Frequency) {
+		http.Error(w, fmt.Sprintf("Frequency %d Hz is outside the valid range (%d-%d Hz)", updatedBookmark.Frequency, singleMinFreq, singleMaxFreq), http.StatusBadRequest)
 		return
 	}
 
@@ -2113,29 +2108,25 @@ func (ah *AdminHandler) handleGetBands(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(bandsConfig)
 }
 
-// validateAndClampBandFrequencies validates and clamps band frequencies to the valid range (10 kHz - 30 MHz)
+// validateAndClampBandFrequencies validates and clamps band frequencies to receiver coverage.
 // Returns error if band is completely outside the valid range, otherwise clamps and returns nil
-func validateAndClampBandFrequencies(band *Band) error {
-	const minFreq uint64 = 10000    // 10 kHz in Hz
-	const maxFreq uint64 = 30000000 // 30 MHz in Hz
+func validateAndClampBandFrequencies(band *Band, minFreq, maxFreq uint64) error {
 
-	// Reject bands that end below 10 kHz or start above 30 MHz
 	if band.End < minFreq {
-		return fmt.Errorf("band ends below minimum frequency (10 kHz)")
+		return fmt.Errorf("band ends below minimum frequency (%d Hz)", minFreq)
 	}
 	if band.Start > maxFreq {
-		return fmt.Errorf("band starts above maximum frequency (30 MHz)")
+		return fmt.Errorf("band starts above maximum frequency (%d Hz)", maxFreq)
 	}
 
 	// Clamp start frequency to 10 kHz minimum
 	if band.Start < minFreq {
-		log.Printf("Clamping band '%s' start frequency from %d Hz to %d Hz (10 kHz)", band.Label, band.Start, minFreq)
+		log.Printf("Clamping band '%s' start frequency from %d Hz to %d Hz", band.Label, band.Start, minFreq)
 		band.Start = minFreq
 	}
 
-	// Clamp end frequency to 30 MHz maximum
 	if band.End > maxFreq {
-		log.Printf("Clamping band '%s' end frequency from %d Hz to %d Hz (30 MHz)", band.Label, band.End, maxFreq)
+		log.Printf("Clamping band '%s' end frequency from %d Hz to %d Hz", band.Label, band.End, maxFreq)
 		band.End = maxFreq
 	}
 
@@ -2167,8 +2158,9 @@ func (ah *AdminHandler) handleAddBand(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate and clamp frequencies to valid range (10 kHz - 30 MHz)
-	if err := validateAndClampBandFrequencies(&newBand); err != nil {
+	// Validate and clamp frequencies to configured receiver coverage.
+	minFreq, maxFreq := ah.config.FrequencyRange()
+	if err := validateAndClampBandFrequencies(&newBand, minFreq, maxFreq); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -2312,7 +2304,8 @@ func (ah *AdminHandler) handleUpdateBands(w http.ResponseWriter, r *http.Request
 				}
 
 				// Validate and clamp frequencies
-				if err := validateAndClampBandFrequencies(&band); err != nil {
+				minFreq, maxFreq := ah.config.FrequencyRange()
+				if err := validateAndClampBandFrequencies(&band, minFreq, maxFreq); err != nil {
 					log.Printf("Skipping band '%s': %v", band.Label, err)
 					skippedCount++
 					continue
@@ -2393,8 +2386,9 @@ func (ah *AdminHandler) handleUpdateBands(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// Validate and clamp frequencies to valid range (10 kHz - 30 MHz)
-	if err := validateAndClampBandFrequencies(&updatedBand); err != nil {
+	// Validate and clamp frequencies to configured receiver coverage.
+	minFreq, maxFreq := ah.config.FrequencyRange()
+	if err := validateAndClampBandFrequencies(&updatedBand, minFreq, maxFreq); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -3949,12 +3943,13 @@ func (ah *AdminHandler) HandleSDRSharpImport(w http.ResponseWriter, r *http.Requ
 	// Convert SDR# bands to our format
 	var bands []interface{}
 	skippedCount := 0
-	const minFreq = 10000     // 10 kHz in Hz
-	const maxFreq = 30000000  // 30 MHz in Hz
+	configuredMin, configuredMax := ah.config.FrequencyRange()
+	minFreq := int(configuredMin)
+	maxFreq := int(configuredMax)
 	const cwCutoff = 10000000 // 10 MHz cutoff for CW mode conversion
 
 	for _, entry := range sdrBands.Entries {
-		// Skip bands that end below 10 kHz or start above 30 MHz
+		// Skip bands outside the active receiver's configured coverage.
 		if entry.MaxFrequency < minFreq || entry.MinFrequency > maxFreq {
 			skippedCount++
 			continue
@@ -3965,13 +3960,13 @@ func (ah *AdminHandler) HandleSDRSharpImport(w http.ResponseWriter, r *http.Requ
 			continue
 		}
 
-		// Clamp start frequency to 10 kHz if it's below the limit
+		// Clamp start frequency to receiver coverage.
 		startFreq := entry.MinFrequency
 		if startFreq < minFreq {
 			startFreq = minFreq
 		}
 
-		// Clamp end frequency to 30 MHz if it exceeds the limit
+		// Clamp end frequency to receiver coverage.
 		endFreq := entry.MaxFrequency
 		if endFreq > maxFreq {
 			endFreq = maxFreq
@@ -4004,7 +3999,7 @@ func (ah *AdminHandler) HandleSDRSharpImport(w http.ResponseWriter, r *http.Requ
 	}
 
 	if len(bands) == 0 {
-		http.Error(w, "No valid bands found in XML file (all bands may be > 30 MHz)", http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("No valid bands found in XML file (receiver range is %d-%d Hz)", minFreq, maxFreq), http.StatusBadRequest)
 		return
 	}
 
@@ -4046,7 +4041,7 @@ func (ah *AdminHandler) HandleSDRSharpImport(w http.ResponseWriter, r *http.Requ
 	// Build response message
 	message := fmt.Sprintf("Successfully imported %d band(s) from SDR# XML", len(bands))
 	if skippedCount > 0 {
-		message += fmt.Sprintf(" (skipped %d band(s) outside 10 kHz - 30 MHz range)", skippedCount)
+		message += fmt.Sprintf(" (skipped %d band(s) outside %d-%d Hz receiver range)", skippedCount, minFreq, maxFreq)
 	}
 
 	w.WriteHeader(http.StatusOK)
@@ -4849,6 +4844,58 @@ func (ah *AdminHandler) HandleRadiodConfig(w http.ResponseWriter, r *http.Reques
 		ah.handleGetRadiodConfig(w, r)
 	case http.MethodPut:
 		ah.handleUpdateRadiodConfig(w, r)
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// HandleReceiverProfiles exposes the installed receiver adapter catalog and
+// previews a radiod configuration for a selected native driver. It does not
+// write files or restart services; the existing radiod-config endpoint remains
+// responsible for applying an explicitly reviewed configuration.
+func (ah *AdminHandler) HandleReceiverProfiles(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	switch r.Method {
+	case http.MethodGet:
+		backends := make([]map[string]interface{}, 0, len(defaultSDRBackends.IDs()))
+		for _, id := range defaultSDRBackends.IDs() {
+			backend, _ := defaultSDRBackends.Lookup(id)
+			backends = append(backends, map[string]interface{}{
+				"id":           backend.ID(),
+				"display_name": backend.DisplayName(),
+				"capabilities": backend.Capabilities(),
+			})
+		}
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"active":   ah.config.Receiver,
+			"backends": backends,
+			"drivers":  defaultSDRDeviceProfiles.Profiles(),
+		}); err != nil {
+			log.Printf("Error encoding receiver profiles: %v", err)
+		}
+
+	case http.MethodPost:
+		var receiver ReceiverConfig
+		decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 1<<20))
+		decoder.DisallowUnknownFields()
+		if err := decoder.Decode(&receiver); err != nil {
+			http.Error(w, fmt.Sprintf("Invalid receiver configuration: %v", err), http.StatusBadRequest)
+			return
+		}
+		configText, err := BuildRadiodConfig(receiver, ah.config.Radiod)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("Cannot generate radiod configuration: %v", err), http.StatusBadRequest)
+			return
+		}
+		receiver.applyDefaults()
+		if err := json.NewEncoder(w).Encode(map[string]interface{}{
+			"receiver": receiver,
+			"config":   configText,
+		}); err != nil {
+			log.Printf("Error encoding generated radiod config: %v", err)
+		}
+
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}

--- a/audio_extensions/digitalvoice/events.go
+++ b/audio_extensions/digitalvoice/events.go
@@ -1,0 +1,109 @@
+package digitalvoice
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	messageEvent = byte(0x40)
+	messageAudio = byte(0x41)
+	messageError = byte(0x42)
+)
+
+var (
+	ansiPattern        = regexp.MustCompile(`\x1b\[[0-9;?]*[ -/]*[@-~]`)
+	colorCodePattern   = regexp.MustCompile(`(?i)color\s+code\s*=\s*(\d+)`)
+	slotPattern        = regexp.MustCompile(`(?i)(?:slot|vc)\s*([12])`)
+	sourcePattern      = regexp.MustCompile(`(?i)(?:source|src|from)\s*[:=]\s*(\d+)`)
+	targetPattern      = regexp.MustCompile(`(?i)(?:target|tgt|to|group)\s*[:=]\s*(\d+)`)
+	nacPattern         = regexp.MustCompile(`(?i)\bNAC\s*[:=]\s*([0-9a-f]+)`)
+	encryptedPattern   = regexp.MustCompile(`(?i)\b(?:encrypted|encryption|enc)\b`)
+	interestingPattern = regexp.MustCompile(`(?i)(sync:|DMR|P25|NXDN|D-?STAR|YSF|M17|dPMR|ProVoice|EDACS|X2-TDMA|voice|data|call|color\s+code|NAC|error|warning)`)
+)
+
+// Event is sent to the browser as a JSON payload prefixed with messageEvent.
+// Raw contains DSD-FME's human-readable decode line; commonly useful fields
+// are also normalized when present.
+type Event struct {
+	Type      string `json:"type"`
+	Protocol  string `json:"protocol"`
+	Timestamp string `json:"timestamp"`
+	Raw       string `json:"raw"`
+	Encrypted bool   `json:"encrypted,omitempty"`
+	Slot      int    `json:"slot,omitempty"`
+	ColorCode int    `json:"color_code,omitempty"`
+	SourceID  int64  `json:"source_id,omitempty"`
+	TargetID  int64  `json:"target_id,omitempty"`
+	NAC       string `json:"nac,omitempty"`
+}
+
+func parseEvent(defaultProtocol, line string, now time.Time) (Event, bool) {
+	line = strings.TrimSpace(ansiPattern.ReplaceAllString(line, ""))
+	if line == "" || !interestingPattern.MatchString(line) {
+		return Event{}, false
+	}
+
+	event := Event{
+		Type:      "digital_voice_event",
+		Protocol:  inferProtocol(defaultProtocol, line),
+		Timestamp: now.UTC().Format(time.RFC3339Nano),
+		Raw:       line,
+		Encrypted: encryptedPattern.MatchString(line),
+	}
+	if match := slotPattern.FindStringSubmatch(line); len(match) == 2 {
+		event.Slot, _ = strconv.Atoi(match[1])
+	}
+	if match := colorCodePattern.FindStringSubmatch(line); len(match) == 2 {
+		event.ColorCode, _ = strconv.Atoi(match[1])
+	}
+	if match := sourcePattern.FindStringSubmatch(line); len(match) == 2 {
+		event.SourceID, _ = strconv.ParseInt(match[1], 10, 64)
+	}
+	if match := targetPattern.FindStringSubmatch(line); len(match) == 2 {
+		event.TargetID, _ = strconv.ParseInt(match[1], 10, 64)
+	}
+	if match := nacPattern.FindStringSubmatch(line); len(match) == 2 {
+		event.NAC = strings.ToUpper(match[1])
+	}
+	return event, true
+}
+
+func inferProtocol(fallback, line string) string {
+	upper := strings.ToUpper(line)
+	switch {
+	case strings.Contains(upper, "DMR"):
+		return "dmr"
+	case strings.Contains(upper, "P25"):
+		return "p25"
+	case strings.Contains(upper, "NXDN"), strings.Contains(upper, "IDAS"):
+		return "nxdn"
+	case strings.Contains(upper, "D-STAR"), strings.Contains(upper, "DSTAR"):
+		return "dstar"
+	case strings.Contains(upper, "YSF"):
+		return "ysf"
+	case strings.Contains(upper, "M17"):
+		return "m17"
+	case strings.Contains(upper, "DPMR"):
+		return "dpmr"
+	case strings.Contains(upper, "PROVOICE"):
+		return "provoice"
+	case strings.Contains(upper, "EDACS"):
+		return "edacs"
+	case strings.Contains(upper, "X2-TDMA"), strings.Contains(upper, "X2TDMA"):
+		return "x2tdma"
+	default:
+		return fallback
+	}
+}
+
+func eventMessage(event Event) []byte {
+	payload, err := json.Marshal(event)
+	if err != nil {
+		return nil
+	}
+	return append([]byte{messageEvent}, payload...)
+}

--- a/audio_extensions/digitalvoice/extension.go
+++ b/audio_extensions/digitalvoice/extension.go
@@ -1,0 +1,428 @@
+package digitalvoice
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultBinaryPath = "dsd-fme"
+	decoderInputRate  = 48000
+)
+
+// Config contains server-controlled settings. It deliberately has no decoder
+// argument or key fields: the integration supports clear/unencrypted reception
+// and encrypted-call metadata only.
+type Config struct {
+	BinaryPath string
+	MaxUsers   int
+}
+
+// GlobalConfig is populated by the main package before registration.
+var GlobalConfig = &Config{BinaryPath: defaultBinaryPath, MaxUsers: 3}
+
+var (
+	activeUsers int
+	activeMu    sync.Mutex
+)
+
+type AudioExtensionParams struct {
+	SampleRate    int
+	Channels      int
+	BitsPerSample int
+}
+
+type AudioSample struct {
+	PCMData      []int16
+	RTPTimestamp uint32
+	GPSTimeNs    int64
+}
+
+type AudioExtension interface {
+	Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error
+	Stop() error
+	GetName() string
+}
+
+// DigitalVoiceExtension supervises one DSD-FME process for one listener.
+type DigitalVoiceExtension struct {
+	audioParams AudioExtensionParams
+	profile     Profile
+	binaryPath  string
+	inverted    bool
+	resampler   *linearResampler
+
+	mu          sync.Mutex
+	cmd         *exec.Cmd
+	stdin       io.WriteCloser
+	udp         *net.UDPConn
+	stopChan    chan struct{}
+	crashChan   chan error
+	stopOnce    sync.Once
+	releaseOnce sync.Once
+	wg          sync.WaitGroup
+	running     atomic.Bool
+	stopping    atomic.Bool
+	latestTime  atomic.Int64
+	// Refreshed by encrypted decoder events. This explicitly suppresses
+	// encrypted output in addition to DSD-FME's normal encrypted-voice muting.
+	suppressAudioUntil atomic.Int64
+	acquired           bool
+}
+
+// Factory validates a client request and creates a decoder instance.
+func Factory(audioParams AudioExtensionParams, extensionParams map[string]interface{}) (AudioExtension, error) {
+	if audioParams.Channels != 1 {
+		return nil, fmt.Errorf("digital voice decoding requires mono demodulated audio; use NFM mode (got %d channels)", audioParams.Channels)
+	}
+	if audioParams.BitsPerSample != 16 {
+		return nil, fmt.Errorf("digital voice decoding requires 16-bit PCM (got %d bits)", audioParams.BitsPerSample)
+	}
+	if audioParams.SampleRate < 8000 || audioParams.SampleRate > 192000 {
+		return nil, fmt.Errorf("unsupported input sample rate %d Hz", audioParams.SampleRate)
+	}
+
+	protocol := stringParam(extensionParams, "protocol", "auto")
+	profile, err := LookupProfile(protocol)
+	if err != nil {
+		return nil, err
+	}
+	inverted := boolParam(extensionParams, "inverted", false)
+	if inverted && profile.InversionArg == "" {
+		return nil, fmt.Errorf("%s does not support the inverted-signal option", profile.Name)
+	}
+
+	binaryPath := defaultBinaryPath
+	if GlobalConfig != nil && strings.TrimSpace(GlobalConfig.BinaryPath) != "" {
+		binaryPath = strings.TrimSpace(GlobalConfig.BinaryPath)
+	}
+	if err := validateBinary(binaryPath); err != nil {
+		return nil, err
+	}
+
+	return &DigitalVoiceExtension{
+		audioParams: audioParams,
+		profile:     profile,
+		binaryPath:  binaryPath,
+		inverted:    inverted,
+		resampler:   newLinearResampler(audioParams.SampleRate, decoderInputRate),
+		stopChan:    make(chan struct{}),
+		crashChan:   make(chan error, 1),
+	}, nil
+}
+
+func validateBinary(path string) error {
+	if filepath.IsAbs(path) || strings.ContainsAny(path, `/\`) {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("DSD-FME binary not found at %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("DSD-FME binary path is a directory: %s", path)
+		}
+		return nil
+	}
+	if _, err := exec.LookPath(path); err != nil {
+		return fmt.Errorf("DSD-FME binary %q not found in PATH", path)
+	}
+	return nil
+}
+
+func (e *DigitalVoiceExtension) Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.running.Load() {
+		return errors.New("digital voice decoder already running")
+	}
+	if err := e.acquireUser(); err != nil {
+		return err
+	}
+
+	udp, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		e.releaseUser()
+		return fmt.Errorf("open decoded-audio listener: %w", err)
+	}
+	e.udp = udp
+	port := udp.LocalAddr().(*net.UDPAddr).Port
+
+	args, err := BuildArgs(e.profile, port, e.inverted)
+	if err != nil {
+		udp.Close()
+		e.releaseUser()
+		return err
+	}
+	cmd := exec.Command(e.binaryPath, args...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		udp.Close()
+		e.releaseUser()
+		return fmt.Errorf("open DSD-FME input: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		stdin.Close()
+		udp.Close()
+		e.releaseUser()
+		return fmt.Errorf("open DSD-FME event stream: %w", err)
+	}
+	cmd.Stdout = io.Discard
+	if err := cmd.Start(); err != nil {
+		stdin.Close()
+		udp.Close()
+		e.releaseUser()
+		return fmt.Errorf("start DSD-FME: %w", err)
+	}
+
+	e.cmd = cmd
+	e.stdin = stdin
+	e.running.Store(true)
+	e.stopping.Store(false)
+
+	e.sendEvent(resultChan, Event{
+		Type: "digital_voice_started", Protocol: e.profile.ID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+		Raw:       fmt.Sprintf("%s decoder started; clear/unencrypted audio only", e.profile.Name),
+	})
+
+	e.wg.Add(4)
+	go e.feedAudio(audioChan)
+	go e.readDecodedAudio(resultChan)
+	go e.readEvents(stderr, resultChan)
+	go e.waitProcess(resultChan)
+	return nil
+}
+
+func (e *DigitalVoiceExtension) feedAudio(audioChan <-chan AudioSample) {
+	defer e.wg.Done()
+	for {
+		select {
+		case <-e.stopChan:
+			return
+		case sample, ok := <-audioChan:
+			if !ok {
+				return
+			}
+			if sample.GPSTimeNs != 0 {
+				e.latestTime.Store(sample.GPSTimeNs)
+			}
+			pcm := e.resampler.process(sample.PCMData)
+			if len(pcm) == 0 {
+				continue
+			}
+			buffer := make([]byte, len(pcm)*2)
+			for i, value := range pcm {
+				binary.LittleEndian.PutUint16(buffer[i*2:], uint16(value))
+			}
+			if err := writeAll(e.stdin, buffer); err != nil {
+				if !e.stopping.Load() {
+					e.reportCrash(fmt.Errorf("write DSD-FME audio: %w", err))
+				}
+				return
+			}
+		}
+	}
+}
+
+func writeAll(writer io.Writer, data []byte) error {
+	for len(data) > 0 {
+		n, err := writer.Write(data)
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[n:]
+	}
+	return nil
+}
+
+func (e *DigitalVoiceExtension) readDecodedAudio(resultChan chan<- []byte) {
+	defer e.wg.Done()
+	buffer := make([]byte, 65535)
+	for {
+		n, _, err := e.udp.ReadFromUDP(buffer)
+		if err != nil {
+			if !e.stopping.Load() && !errors.Is(err, net.ErrClosed) {
+				e.reportCrash(fmt.Errorf("read DSD-FME decoded audio: %w", err))
+			}
+			return
+		}
+		if n == 0 {
+			continue
+		}
+		if time.Now().UnixNano() < e.suppressAudioUntil.Load() {
+			continue
+		}
+		timestamp := e.latestTime.Load()
+		if timestamp == 0 {
+			timestamp = time.Now().UnixNano()
+		}
+		message := make([]byte, 14+n)
+		message[0] = messageAudio
+		binary.BigEndian.PutUint64(message[1:9], uint64(timestamp))
+		binary.BigEndian.PutUint32(message[9:13], uint32(e.profile.OutputSampleRate))
+		message[13] = byte(e.profile.OutputChannels)
+		copy(message[14:], buffer[:n])
+		sendResult(resultChan, message)
+	}
+}
+
+func (e *DigitalVoiceExtension) readEvents(stderr io.Reader, resultChan chan<- []byte) {
+	defer e.wg.Done()
+	scanner := bufio.NewScanner(stderr)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		if event, ok := parseEvent(e.profile.ID, scanner.Text(), time.Now()); ok {
+			if event.Encrypted {
+				e.suppressAudioUntil.Store(time.Now().Add(5 * time.Second).UnixNano())
+			}
+			e.sendEvent(resultChan, event)
+		}
+	}
+	if err := scanner.Err(); err != nil && !e.stopping.Load() {
+		e.reportCrash(fmt.Errorf("read DSD-FME events: %w", err))
+	}
+}
+
+func (e *DigitalVoiceExtension) waitProcess(resultChan chan<- []byte) {
+	defer e.wg.Done()
+	err := e.cmd.Wait()
+	e.running.Store(false)
+	e.releaseUser()
+	if !e.stopping.Load() {
+		if err == nil {
+			err = errors.New("DSD-FME exited unexpectedly")
+		} else {
+			err = fmt.Errorf("DSD-FME exited unexpectedly: %w", err)
+		}
+		e.sendError(resultChan, err)
+		e.reportCrash(err)
+	}
+}
+
+func (e *DigitalVoiceExtension) Stop() error {
+	e.stopOnce.Do(func() {
+		e.stopping.Store(true)
+		e.running.Store(false)
+		close(e.stopChan)
+
+		e.mu.Lock()
+		stdin := e.stdin
+		udp := e.udp
+		cmd := e.cmd
+		e.mu.Unlock()
+
+		if stdin != nil {
+			_ = stdin.Close()
+		}
+		if udp != nil {
+			_ = udp.Close()
+		}
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		e.releaseUser()
+	})
+	e.wg.Wait()
+	return nil
+}
+
+func (e *DigitalVoiceExtension) GetName() string {
+	return "digitalvoice"
+}
+
+func (e *DigitalVoiceExtension) CrashChan() <-chan error {
+	return e.crashChan
+}
+
+func (e *DigitalVoiceExtension) reportCrash(err error) {
+	select {
+	case e.crashChan <- err:
+	default:
+	}
+}
+
+func (e *DigitalVoiceExtension) sendEvent(resultChan chan<- []byte, event Event) {
+	if message := eventMessage(event); len(message) > 1 {
+		sendResult(resultChan, message)
+	}
+}
+
+func (e *DigitalVoiceExtension) sendError(resultChan chan<- []byte, err error) {
+	payload, _ := json.Marshal(map[string]string{
+		"type": "digital_voice_error", "error": err.Error(),
+	})
+	sendResult(resultChan, append([]byte{messageError}, payload...))
+}
+
+func sendResult(resultChan chan<- []byte, message []byte) {
+	select {
+	case resultChan <- message:
+	default:
+	}
+}
+
+func (e *DigitalVoiceExtension) acquireUser() error {
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	maxUsers := 3
+	if GlobalConfig != nil {
+		maxUsers = GlobalConfig.MaxUsers
+	}
+	if maxUsers > 0 && activeUsers >= maxUsers {
+		return fmt.Errorf("digital voice decoder is at capacity (%d concurrent users)", maxUsers)
+	}
+	activeUsers++
+	e.acquired = true
+	return nil
+}
+
+func (e *DigitalVoiceExtension) releaseUser() {
+	e.releaseOnce.Do(func() {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		if e.acquired && activeUsers > 0 {
+			activeUsers--
+		}
+		e.acquired = false
+	})
+}
+
+func stringParam(params map[string]interface{}, key, fallback string) string {
+	if value, ok := params[key].(string); ok && strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
+}
+
+func boolParam(params map[string]interface{}, key string, fallback bool) bool {
+	if value, ok := params[key].(bool); ok {
+		return value
+	}
+	return fallback
+}
+
+// GetInfo returns metadata for the main audio-extension registry.
+func GetInfo() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "digitalvoice",
+		"description": "Receive-only DMR, P25, NXDN, D-Star, YSF, M17, dPMR, ProVoice/EDACS and X2-TDMA via DSD-FME",
+		"version":     "1.0.0",
+		"profiles":    Profiles(),
+		"security":    "No client-supplied decoder arguments or privacy/decryption keys are accepted. Encrypted-call metadata may be displayed, but encrypted voice is not decoded.",
+	}
+}

--- a/audio_extensions/digitalvoice/profiles.go
+++ b/audio_extensions/digitalvoice/profiles.go
@@ -1,0 +1,141 @@
+package digitalvoice
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Profile describes a protocol mode exposed by the digital-voice extension.
+// DecoderArgs are intentionally fixed. Client-supplied command-line arguments
+// are never accepted, which keeps DSD-FME privacy/decryption key options out of
+// the public extension API.
+type Profile struct {
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name"`
+	Description          string   `json:"description"`
+	DecoderArgs          []string `json:"-"`
+	InversionArg         string   `json:"-"`
+	OutputSampleRate     int      `json:"output_sample_rate"`
+	OutputChannels       int      `json:"output_channels"`
+	RecommendedMode      string   `json:"recommended_mode"`
+	RecommendedBandwidth int      `json:"recommended_bandwidth_hz"`
+}
+
+var profiles = map[string]Profile{
+	"auto": {
+		ID: "auto", Name: "Auto", Description: "Automatic DMR, P25, YSF, D-Star and X2-TDMA detection",
+		DecoderArgs: []string{"-fa"}, OutputSampleRate: 8000, OutputChannels: 2,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"dmr": {
+		ID: "dmr", Name: "DMR", Description: "DMR Tier II conventional/base-station and mobile simplex",
+		DecoderArgs: []string{"-fs"}, InversionArg: "-xr", OutputSampleRate: 8000, OutputChannels: 2,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"p25p1": {
+		ID: "p25p1", Name: "P25 Phase 1", Description: "APCO Project 25 Phase 1 FDMA",
+		DecoderArgs: []string{"-f1"}, OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"p25p2": {
+		ID: "p25p2", Name: "P25 Phase 2", Description: "APCO Project 25 Phase 2 TDMA traffic channels",
+		DecoderArgs: []string{"-f2"}, OutputSampleRate: 8000, OutputChannels: 2,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"nxdn48": {
+		ID: "nxdn48", Name: "NXDN48 / IDAS", Description: "6.25 kHz NXDN and IDAS",
+		DecoderArgs: []string{"-fi"}, InversionArg: "-xn", OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 7000,
+	},
+	"nxdn96": {
+		ID: "nxdn96", Name: "NXDN96", Description: "12.5 kHz NXDN",
+		DecoderArgs: []string{"-fn"}, InversionArg: "-xn", OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"dstar": {
+		ID: "dstar", Name: "D-Star", Description: "D-Star digital voice",
+		DecoderArgs: []string{"-fd"}, OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"ysf": {
+		ID: "ysf", Name: "YSF", Description: "Yaesu System Fusion",
+		DecoderArgs: []string{"-fy"}, OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"m17": {
+		ID: "m17", Name: "M17", Description: "M17 digital voice",
+		DecoderArgs: []string{"-fz"}, InversionArg: "-xz", OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"dpmr": {
+		ID: "dpmr", Name: "dPMR", Description: "dPMR digital voice",
+		DecoderArgs: []string{"-fm"}, InversionArg: "-xd", OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 7000,
+	},
+	"provoice": {
+		ID: "provoice", Name: "ProVoice", Description: "Conventional ProVoice",
+		DecoderArgs: []string{"-fp"}, OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 24000,
+	},
+	"edacs": {
+		ID: "edacs", Name: "EDACS / ProVoice", Description: "EDACS Standard control and ProVoice",
+		DecoderArgs: []string{"-fh"}, OutputSampleRate: 8000, OutputChannels: 1,
+		RecommendedMode: "nfm", RecommendedBandwidth: 24000,
+	},
+	"x2tdma": {
+		ID: "x2tdma", Name: "X2-TDMA", Description: "Motorola X2-TDMA",
+		DecoderArgs: []string{"-fx"}, OutputSampleRate: 8000, OutputChannels: 2,
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+}
+
+// LookupProfile returns a copy of an allowlisted protocol profile.
+func LookupProfile(id string) (Profile, error) {
+	id = strings.ToLower(strings.TrimSpace(id))
+	profile, ok := profiles[id]
+	if !ok {
+		return Profile{}, fmt.Errorf("unsupported digital voice protocol %q", id)
+	}
+	profile.DecoderArgs = append([]string(nil), profile.DecoderArgs...)
+	return profile, nil
+}
+
+// Profiles returns the allowlisted profiles in stable display order.
+func Profiles() []Profile {
+	ids := make([]string, 0, len(profiles))
+	for id := range profiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	result := make([]Profile, 0, len(ids))
+	for _, id := range ids {
+		profile, _ := LookupProfile(id)
+		result = append(result, profile)
+	}
+	return result
+}
+
+// BuildArgs constructs the complete, non-decrypting DSD-FME command line.
+func BuildArgs(profile Profile, udpPort int, inverted bool) ([]string, error) {
+	if udpPort < 1 || udpPort > 65535 {
+		return nil, fmt.Errorf("invalid UDP output port %d", udpPort)
+	}
+	if inverted && profile.InversionArg == "" {
+		return nil, fmt.Errorf("%s does not expose an inverted-signal mode", profile.Name)
+	}
+
+	args := append([]string(nil), profile.DecoderArgs...)
+	if inverted {
+		args = append(args, profile.InversionArg)
+	}
+	// DSD-FME accepts raw signed 16-bit little-endian mono PCM from stdin when
+	// "-" is selected as the input. Its UDP output is raw decoded 8 kHz PCM.
+	args = append(args,
+		"-i", "-",
+		"-s", "48000",
+		"-o", fmt.Sprintf("udp:127.0.0.1:%d", udpPort),
+	)
+	return args, nil
+}

--- a/audio_extensions/digitalvoice/profiles_test.go
+++ b/audio_extensions/digitalvoice/profiles_test.go
@@ -1,0 +1,63 @@
+package digitalvoice
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestBuildArgsDMR(t *testing.T) {
+	profile, err := LookupProfile("dmr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := BuildArgs(profile, 23456, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"-fs", "-xr", "-i", "-", "-s", "48000", "-o", "udp:127.0.0.1:23456"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildArgsRejectsUnsupportedInversion(t *testing.T) {
+	profile, err := LookupProfile("p25p1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildArgs(profile, 23456, true); err == nil {
+		t.Fatal("expected unsupported inversion error")
+	}
+}
+
+func TestProfilesContainPriorityProtocols(t *testing.T) {
+	for _, id := range []string{"dmr", "p25p1", "p25p2", "nxdn48", "nxdn96", "dstar", "ysf", "m17", "dpmr"} {
+		if _, err := LookupProfile(id); err != nil {
+			t.Errorf("priority protocol %q missing: %v", id, err)
+		}
+	}
+}
+
+func TestResamplerMaintainsPacketBoundary(t *testing.T) {
+	resampler := newLinearResampler(24000, 48000)
+	first := resampler.process([]int16{0, 1000, 2000})
+	second := resampler.process([]int16{3000, 4000})
+	got := append(first, second...)
+	want := []int16{0, 500, 1000, 1500, 2000, 2500, 3000, 3500}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("resampled output = %v, want %v", got, want)
+	}
+}
+
+func TestParseDMREvent(t *testing.T) {
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+	event, ok := parseEvent("auto", "Sync: +DMR slot1 | Color Code=03 | Source=123 Target=456 ENC", now)
+	if !ok {
+		t.Fatal("expected event")
+	}
+	if event.Protocol != "dmr" || event.Slot != 1 || event.ColorCode != 3 ||
+		event.SourceID != 123 || event.TargetID != 456 || !event.Encrypted {
+		t.Fatalf("unexpected parsed event: %+v", event)
+	}
+}

--- a/audio_extensions/digitalvoice/resampler.go
+++ b/audio_extensions/digitalvoice/resampler.go
@@ -1,0 +1,63 @@
+package digitalvoice
+
+import "math"
+
+// linearResampler is a small stateful mono PCM resampler. UberSDR's NFM
+// sessions normally provide 24 kHz audio, while DSD-FME's discriminator input
+// operates at 48 kHz. Keeping phase and the last sample across packet
+// boundaries avoids discontinuities in the symbol stream.
+type linearResampler struct {
+	inputRate  int
+	outputRate int
+	position   float64
+	previous   int16
+	havePrev   bool
+}
+
+func newLinearResampler(inputRate, outputRate int) *linearResampler {
+	return &linearResampler{inputRate: inputRate, outputRate: outputRate}
+}
+
+func (r *linearResampler) process(input []int16) []int16 {
+	if len(input) == 0 {
+		return nil
+	}
+	if r.inputRate == r.outputRate {
+		return append([]int16(nil), input...)
+	}
+
+	samples := input
+	if r.havePrev {
+		samples = make([]int16, 0, len(input)+1)
+		samples = append(samples, r.previous)
+		samples = append(samples, input...)
+	}
+	if len(samples) < 2 {
+		r.previous = samples[len(samples)-1]
+		r.havePrev = true
+		return nil
+	}
+
+	step := float64(r.inputRate) / float64(r.outputRate)
+	estimated := int(math.Ceil(float64(len(samples)-1) / step))
+	output := make([]int16, 0, estimated)
+	for r.position < float64(len(samples)-1) {
+		index := int(r.position)
+		fraction := r.position - float64(index)
+		left := float64(samples[index])
+		right := float64(samples[index+1])
+		value := left + (right-left)*fraction
+		if value > math.MaxInt16 {
+			value = math.MaxInt16
+		} else if value < math.MinInt16 {
+			value = math.MinInt16
+		}
+		output = append(output, int16(math.Round(value)))
+		r.position += step
+	}
+
+	r.position -= float64(len(samples) - 1)
+	r.previous = samples[len(samples)-1]
+	r.havePrev = true
+	return output
+}

--- a/audio_extensions/signalling/extension.go
+++ b/audio_extensions/signalling/extension.go
@@ -1,0 +1,300 @@
+package signalling
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	defaultBinaryPath = "multimon-ng"
+	decoderInputRate  = 22050
+	messageDecode     = byte(0x50)
+	messageError      = byte(0x51)
+)
+
+type Config struct {
+	BinaryPath string
+	MaxUsers   int
+}
+
+var GlobalConfig = &Config{BinaryPath: defaultBinaryPath, MaxUsers: 5}
+
+var (
+	activeUsers int
+	activeMu    sync.Mutex
+)
+
+type AudioExtensionParams struct {
+	SampleRate    int
+	Channels      int
+	BitsPerSample int
+}
+
+type AudioSample struct {
+	PCMData      []int16
+	RTPTimestamp uint32
+	GPSTimeNs    int64
+}
+
+type AudioExtension interface {
+	Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error
+	Stop() error
+	GetName() string
+}
+
+type Extension struct {
+	audioParams AudioExtensionParams
+	profile     Profile
+	binaryPath  string
+	resampler   *linearResampler
+
+	mu          sync.Mutex
+	cmd         *exec.Cmd
+	stdin       io.WriteCloser
+	stopChan    chan struct{}
+	crashChan   chan error
+	stopOnce    sync.Once
+	releaseOnce sync.Once
+	wg          sync.WaitGroup
+	running     atomic.Bool
+	stopping    atomic.Bool
+	acquired    bool
+}
+
+func Factory(audioParams AudioExtensionParams, extensionParams map[string]interface{}) (AudioExtension, error) {
+	if audioParams.Channels != 1 || audioParams.BitsPerSample != 16 {
+		return nil, fmt.Errorf("signalling decoding requires mono 16-bit demodulated audio")
+	}
+	if audioParams.SampleRate < 8000 || audioParams.SampleRate > 192000 {
+		return nil, fmt.Errorf("unsupported input sample rate %d Hz", audioParams.SampleRate)
+	}
+	profileID := "paging"
+	if value, ok := extensionParams["profile"].(string); ok && strings.TrimSpace(value) != "" {
+		profileID = value
+	}
+	profile, err := LookupProfile(profileID)
+	if err != nil {
+		return nil, err
+	}
+	binaryPath := defaultBinaryPath
+	if GlobalConfig != nil && strings.TrimSpace(GlobalConfig.BinaryPath) != "" {
+		binaryPath = strings.TrimSpace(GlobalConfig.BinaryPath)
+	}
+	if err := validateBinary(binaryPath); err != nil {
+		return nil, err
+	}
+	return &Extension{
+		audioParams: audioParams,
+		profile:     profile,
+		binaryPath:  binaryPath,
+		resampler:   newLinearResampler(audioParams.SampleRate, decoderInputRate),
+		stopChan:    make(chan struct{}),
+		crashChan:   make(chan error, 1),
+	}, nil
+}
+
+func validateBinary(path string) error {
+	if filepath.IsAbs(path) || strings.ContainsAny(path, `/\`) {
+		info, err := os.Stat(path)
+		if err != nil {
+			return fmt.Errorf("multimon-ng binary not found at %s: %w", path, err)
+		}
+		if info.IsDir() {
+			return fmt.Errorf("multimon-ng binary path is a directory: %s", path)
+		}
+		return nil
+	}
+	if _, err := exec.LookPath(path); err != nil {
+		return fmt.Errorf("multimon-ng binary %q not found in PATH", path)
+	}
+	return nil
+}
+
+func (e *Extension) Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if e.running.Load() {
+		return errors.New("signalling decoder already running")
+	}
+	if err := e.acquireUser(); err != nil {
+		return err
+	}
+
+	cmd := exec.Command(e.binaryPath, BuildArgs(e.profile)...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		e.releaseUser()
+		return fmt.Errorf("open multimon-ng input: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		e.releaseUser()
+		return fmt.Errorf("open multimon-ng output: %w", err)
+	}
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		e.releaseUser()
+		return fmt.Errorf("start multimon-ng: %w", err)
+	}
+	e.cmd = cmd
+	e.stdin = stdin
+	e.running.Store(true)
+	e.stopping.Store(false)
+	e.sendJSON(resultChan, messageDecode, map[string]interface{}{
+		"type": "signalling_started", "profile": e.profile.ID,
+		"timestamp": time.Now().UTC().Format(time.RFC3339Nano),
+	})
+
+	e.wg.Add(3)
+	go e.feedAudio(audioChan)
+	go e.readOutput(stdout, resultChan)
+	go e.waitProcess(resultChan)
+	return nil
+}
+
+func (e *Extension) feedAudio(audioChan <-chan AudioSample) {
+	defer e.wg.Done()
+	for {
+		select {
+		case <-e.stopChan:
+			return
+		case sample, ok := <-audioChan:
+			if !ok {
+				return
+			}
+			pcm := e.resampler.process(sample.PCMData)
+			buffer := make([]byte, len(pcm)*2)
+			for i, value := range pcm {
+				binary.LittleEndian.PutUint16(buffer[i*2:], uint16(value))
+			}
+			if len(buffer) > 0 {
+				if _, err := e.stdin.Write(buffer); err != nil && !e.stopping.Load() {
+					e.reportCrash(fmt.Errorf("write multimon-ng audio: %w", err))
+					return
+				}
+			}
+		}
+	}
+}
+
+func (e *Extension) readOutput(reader io.Reader, resultChan chan<- []byte) {
+	defer e.wg.Done()
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 4096), 1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		e.sendJSON(resultChan, messageDecode, map[string]interface{}{
+			"type": "signalling_decode", "profile": e.profile.ID,
+			"timestamp": time.Now().UTC().Format(time.RFC3339Nano), "raw": line,
+		})
+	}
+	if err := scanner.Err(); err != nil && !e.stopping.Load() {
+		e.reportCrash(fmt.Errorf("read multimon-ng output: %w", err))
+	}
+}
+
+func (e *Extension) waitProcess(resultChan chan<- []byte) {
+	defer e.wg.Done()
+	err := e.cmd.Wait()
+	e.running.Store(false)
+	e.releaseUser()
+	if !e.stopping.Load() {
+		if err == nil {
+			err = errors.New("multimon-ng exited unexpectedly")
+		}
+		e.sendJSON(resultChan, messageError, map[string]interface{}{
+			"type": "signalling_error", "error": err.Error(),
+		})
+		e.reportCrash(err)
+	}
+}
+
+func (e *Extension) Stop() error {
+	e.stopOnce.Do(func() {
+		e.stopping.Store(true)
+		e.running.Store(false)
+		close(e.stopChan)
+		e.mu.Lock()
+		stdin, cmd := e.stdin, e.cmd
+		e.mu.Unlock()
+		if stdin != nil {
+			_ = stdin.Close()
+		}
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+		e.releaseUser()
+	})
+	e.wg.Wait()
+	return nil
+}
+
+func (e *Extension) GetName() string         { return "signalling" }
+func (e *Extension) CrashChan() <-chan error { return e.crashChan }
+func (e *Extension) reportCrash(err error) {
+	select {
+	case e.crashChan <- err:
+	default:
+	}
+}
+func (e *Extension) sendJSON(resultChan chan<- []byte, messageType byte, value interface{}) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	select {
+	case resultChan <- append([]byte{messageType}, payload...):
+	default:
+	}
+}
+
+func (e *Extension) acquireUser() error {
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	maxUsers := 5
+	if GlobalConfig != nil {
+		maxUsers = GlobalConfig.MaxUsers
+	}
+	if maxUsers > 0 && activeUsers >= maxUsers {
+		return fmt.Errorf("signalling decoder is at capacity (%d concurrent users)", maxUsers)
+	}
+	activeUsers++
+	e.acquired = true
+	return nil
+}
+
+func (e *Extension) releaseUser() {
+	e.releaseOnce.Do(func() {
+		activeMu.Lock()
+		defer activeMu.Unlock()
+		if e.acquired && activeUsers > 0 {
+			activeUsers--
+		}
+		e.acquired = false
+	})
+}
+
+func GetInfo() map[string]interface{} {
+	return map[string]interface{}{
+		"name":        "signalling",
+		"description": "POCSAG/FLEX paging, SAME/EAS, DTMF, two-tone and legacy telemetry via multimon-ng",
+		"version":     "1.0.0",
+		"profiles":    Profiles(),
+	}
+}

--- a/audio_extensions/signalling/profiles.go
+++ b/audio_extensions/signalling/profiles.go
@@ -1,0 +1,101 @@
+package signalling
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Profile is an allowlisted multimon-ng decoder set. Browser clients select a
+// profile but can never supply executable paths, decoder names, or arguments.
+type Profile struct {
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name"`
+	Description          string   `json:"description"`
+	Demodulators         []string `json:"demodulators"`
+	RecommendedMode      string   `json:"recommended_mode"`
+	RecommendedBandwidth int      `json:"recommended_bandwidth_hz"`
+	AlphaPOCSAG          bool     `json:"-"`
+}
+
+var profiles = map[string]Profile{
+	"paging": {
+		ID: "paging", Name: "Paging", Description: "POCSAG 512/1200/2400 and FLEX paging",
+		Demodulators:    []string{"POCSAG512", "POCSAG1200", "POCSAG2400", "FLEX"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000, AlphaPOCSAG: true,
+	},
+	"pocsag": {
+		ID: "pocsag", Name: "POCSAG", Description: "POCSAG 512, 1200 and 2400 baud paging",
+		Demodulators:    []string{"POCSAG512", "POCSAG1200", "POCSAG2400"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000, AlphaPOCSAG: true,
+	},
+	"flex": {
+		ID: "flex", Name: "FLEX", Description: "Motorola FLEX paging",
+		Demodulators:    []string{"FLEX"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000,
+	},
+	"eas": {
+		ID: "eas", Name: "SAME / EAS", Description: "Emergency Alert System SAME headers",
+		Demodulators:    []string{"EAS"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000,
+	},
+	"dtmf": {
+		ID: "dtmf", Name: "DTMF", Description: "Dual-tone multi-frequency digits",
+		Demodulators:    []string{"DTMF"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"twotone": {
+		ID: "twotone", Name: "Two-tone signalling", Description: "ZVEI, CCIR, EEA and EIA selective calling",
+		Demodulators:    []string{"ZVEI1", "ZVEI2", "ZVEI3", "DZVEI", "PZVEI", "CCIR", "EEA", "EIA"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 12000,
+	},
+	"telemetry": {
+		ID: "telemetry", Name: "Legacy telemetry", Description: "UFSK, CLIPFSK and FMSFSK signalling",
+		Demodulators:    []string{"UFSK1200", "CLIPFSK", "FMSFSK"},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000,
+	},
+	"all": {
+		ID: "all", Name: "Auto / all signalling", Description: "Paging, SAME/EAS, DTMF, two-tone and legacy telemetry",
+		Demodulators: []string{
+			"POCSAG512", "POCSAG1200", "POCSAG2400", "FLEX", "EAS", "DTMF",
+			"ZVEI1", "ZVEI2", "ZVEI3", "DZVEI", "PZVEI", "CCIR", "EEA", "EIA",
+			"UFSK1200", "CLIPFSK", "FMSFSK",
+		},
+		RecommendedMode: "nfm", RecommendedBandwidth: 15000, AlphaPOCSAG: true,
+	},
+}
+
+func LookupProfile(id string) (Profile, error) {
+	id = strings.ToLower(strings.TrimSpace(id))
+	profile, ok := profiles[id]
+	if !ok {
+		return Profile{}, fmt.Errorf("unsupported signalling profile %q", id)
+	}
+	profile.Demodulators = append([]string(nil), profile.Demodulators...)
+	return profile, nil
+}
+
+func Profiles() []Profile {
+	ids := make([]string, 0, len(profiles))
+	for id := range profiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	result := make([]Profile, 0, len(ids))
+	for _, id := range ids {
+		profile, _ := LookupProfile(id)
+		result = append(result, profile)
+	}
+	return result
+}
+
+func BuildArgs(profile Profile) []string {
+	args := []string{"-t", "raw", "-q", "--timestamp"}
+	if profile.AlphaPOCSAG {
+		args = append(args, "-f", "alpha")
+	}
+	for _, demodulator := range profile.Demodulators {
+		args = append(args, "-a", demodulator)
+	}
+	return append(args, "-")
+}

--- a/audio_extensions/signalling/profiles_test.go
+++ b/audio_extensions/signalling/profiles_test.go
@@ -1,0 +1,38 @@
+package signalling
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildArgsPaging(t *testing.T) {
+	profile, err := LookupProfile("paging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := BuildArgs(profile)
+	want := []string{
+		"-t", "raw", "-q", "--timestamp", "-f", "alpha",
+		"-a", "POCSAG512", "-a", "POCSAG1200", "-a", "POCSAG2400", "-a", "FLEX", "-",
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("BuildArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestPriorityProfiles(t *testing.T) {
+	for _, id := range []string{"paging", "pocsag", "flex", "eas", "dtmf", "twotone", "telemetry", "all"} {
+		if _, err := LookupProfile(id); err != nil {
+			t.Errorf("profile %q missing: %v", id, err)
+		}
+	}
+}
+
+func TestResamplerProduces22050HzRatio(t *testing.T) {
+	resampler := newLinearResampler(24000, 22050)
+	input := make([]int16, 24000)
+	got := resampler.process(input)
+	if len(got) < 22048 || len(got) > 22051 {
+		t.Fatalf("resampled length = %d, expected approximately 22050", len(got))
+	}
+}

--- a/audio_extensions/signalling/resampler.go
+++ b/audio_extensions/signalling/resampler.go
@@ -1,0 +1,48 @@
+package signalling
+
+import "math"
+
+type linearResampler struct {
+	inputRate  int
+	outputRate int
+	position   float64
+	previous   int16
+	havePrev   bool
+}
+
+func newLinearResampler(inputRate, outputRate int) *linearResampler {
+	return &linearResampler{inputRate: inputRate, outputRate: outputRate}
+}
+
+func (r *linearResampler) process(input []int16) []int16 {
+	if len(input) == 0 {
+		return nil
+	}
+	if r.inputRate == r.outputRate {
+		return append([]int16(nil), input...)
+	}
+	samples := input
+	if r.havePrev {
+		samples = make([]int16, 0, len(input)+1)
+		samples = append(samples, r.previous)
+		samples = append(samples, input...)
+	}
+	if len(samples) < 2 {
+		r.previous = samples[len(samples)-1]
+		r.havePrev = true
+		return nil
+	}
+	step := float64(r.inputRate) / float64(r.outputRate)
+	output := make([]int16, 0, int(math.Ceil(float64(len(samples)-1)/step)))
+	for r.position < float64(len(samples)-1) {
+		index := int(r.position)
+		fraction := r.position - float64(index)
+		value := float64(samples[index]) + (float64(samples[index+1])-float64(samples[index]))*fraction
+		output = append(output, int16(math.Round(value)))
+		r.position += step
+	}
+	r.position -= float64(len(samples) - 1)
+	r.previous = samples[len(samples)-1]
+	r.havePrev = true
+	return output
+}

--- a/chat_websocket.go
+++ b/chat_websocket.go
@@ -469,8 +469,8 @@ func (cm *ChatManager) UpdateUserStatus(sessionID string, updates map[string]int
 
 	// Update frequency if provided AND different
 	if frequency, ok := updates["frequency"].(float64); ok {
-		// Validate frequency (0 Hz to 30 MHz)
-		if frequency > 30000000 {
+		minFrequency, maxFrequency := cm.sessionManager.config.FrequencyRange()
+		if frequency < float64(minFrequency) || frequency > float64(maxFrequency) {
 			cm.activeUsersMu.Unlock()
 			return ErrInvalidFrequency
 		}
@@ -1736,7 +1736,7 @@ var (
 	ErrUpdateRateLimitExceeded = &ChatError{"update rate limit exceeded - please wait before updating frequency/mode"}
 	ErrMaxUsersReached         = &ChatError{"maximum number of chat users reached - please try again later"}
 	ErrUsernameAlreadyTaken    = &ChatError{"username already taken - please choose a different username"}
-	ErrInvalidFrequency        = &ChatError{"invalid frequency - must be between 0 and 30000000 Hz"}
+	ErrInvalidFrequency        = &ChatError{"invalid frequency - outside configured receiver coverage"}
 	ErrInvalidMode             = &ChatError{"invalid mode - must be one of: usb, lsb, am, fm, cwu, cwl, sam, nfm, or any IQ mode (iq, iq48, iq96, iq192, iq384)"}
 	ErrInvalidBandwidth        = &ChatError{"invalid bandwidth - bw_high and bw_low must be between -12000 and 12000 Hz"}
 )

--- a/config.go
+++ b/config.go
@@ -15,43 +15,46 @@ import (
 
 // Config represents the application configuration
 type Config struct {
-	Admin              AdminConfig               `yaml:"admin"`
-	Radiod             RadiodConfig              `yaml:"radiod"`
-	Server             ServerConfig              `yaml:"server"`
-	Audio              AudioConfig               `yaml:"audio"`
-	Spectrum           SpectrumConfig            `yaml:"spectrum"`
-	NoiseFloor         NoiseFloorConfig          `yaml:"noisefloor"`
-	Spectrogram        SpectrogramConfig         `yaml:"spectrogram"`
-	Decoder            DecoderConfig             `yaml:"decoder"`
-	Prometheus         PrometheusConfig          `yaml:"prometheus"`
-	MQTT               MQTTConfig                `yaml:"mqtt"`
-	Logging            LoggingConfig             `yaml:"logging"`
-	Database           DatabaseConfig            `yaml:"database"`
-	DXCluster          DXClusterConfig           `yaml:"dxcluster"`
-	FreeDVReporter     FreeDVReporterConfig      `yaml:"freedv_reporter"`
-	Chat               ChatConfig                `yaml:"chat"`
-	SpaceWeather       SpaceWeatherConfig        `yaml:"spaceweather"`
-	InstanceReporting  InstanceReportingConfig   `yaml:"instance_reporting"`
-	FrequencyReference FrequencyReferenceConfig  `yaml:"frequency_reference"`
-	Rotctl             RotctlConfig              `yaml:"rotctl"`
-	AntSwitch          AntSwitchConfig           `yaml:"ant_switch"`
-	GeoIP              GeoIPConfig               `yaml:"geoip"`
-	SSHProxy           SSHProxyConfig            `yaml:"ssh_proxy"`
-	GPSDO              GPSDOConfig               `yaml:"gpsdo"`
-	MCP                MCPConfig                 `yaml:"mcp"`
-	Whisper            WhisperConfig             `yaml:"whisper"`
-	FreeDVExtension    FreeDVExtensionConfig     `yaml:"freedv_extension"`
-	SoundModem         SoundModemExtensionConfig `yaml:"soundmodem_extension"`
-	EiBi               EiBiConfig                `yaml:"eibi"`
-	NTP                NTPConfig                 `yaml:"ntp"`
-	UI                 UIConfig                  `yaml:"ui"`
-	DSP                DSPConfig                 `yaml:"dsp"`
-	LookupServices     LookupServicesConfig      `yaml:"lookup_services"`
-	MonitorDisplay     MonitorDisplayConfig      `yaml:"monitor_display"`
-	Bookmarks          []Bookmark                `yaml:"bookmarks"`
-	Bands              []Band                    `yaml:"bands"`
-	Extensions         []string                  `yaml:"extensions"`
-	DefaultExtension   string                    `yaml:"default_extension,omitempty"`
+	Admin              AdminConfig                 `yaml:"admin"`
+	Receiver           ReceiverConfig              `yaml:"receiver"`
+	Radiod             RadiodConfig                `yaml:"radiod"`
+	Server             ServerConfig                `yaml:"server"`
+	Audio              AudioConfig                 `yaml:"audio"`
+	Spectrum           SpectrumConfig              `yaml:"spectrum"`
+	NoiseFloor         NoiseFloorConfig            `yaml:"noisefloor"`
+	Spectrogram        SpectrogramConfig           `yaml:"spectrogram"`
+	Decoder            DecoderConfig               `yaml:"decoder"`
+	Prometheus         PrometheusConfig            `yaml:"prometheus"`
+	MQTT               MQTTConfig                  `yaml:"mqtt"`
+	Logging            LoggingConfig               `yaml:"logging"`
+	Database           DatabaseConfig              `yaml:"database"`
+	DXCluster          DXClusterConfig             `yaml:"dxcluster"`
+	FreeDVReporter     FreeDVReporterConfig        `yaml:"freedv_reporter"`
+	Chat               ChatConfig                  `yaml:"chat"`
+	SpaceWeather       SpaceWeatherConfig          `yaml:"spaceweather"`
+	InstanceReporting  InstanceReportingConfig     `yaml:"instance_reporting"`
+	FrequencyReference FrequencyReferenceConfig    `yaml:"frequency_reference"`
+	Rotctl             RotctlConfig                `yaml:"rotctl"`
+	AntSwitch          AntSwitchConfig             `yaml:"ant_switch"`
+	GeoIP              GeoIPConfig                 `yaml:"geoip"`
+	SSHProxy           SSHProxyConfig              `yaml:"ssh_proxy"`
+	GPSDO              GPSDOConfig                 `yaml:"gpsdo"`
+	MCP                MCPConfig                   `yaml:"mcp"`
+	Whisper            WhisperConfig               `yaml:"whisper"`
+	FreeDVExtension    FreeDVExtensionConfig       `yaml:"freedv_extension"`
+	SoundModem         SoundModemExtensionConfig   `yaml:"soundmodem_extension"`
+	DigitalVoice       DigitalVoiceExtensionConfig `yaml:"digital_voice_extension"`
+	Signalling         SignallingExtensionConfig   `yaml:"signalling_extension"`
+	EiBi               EiBiConfig                  `yaml:"eibi"`
+	NTP                NTPConfig                   `yaml:"ntp"`
+	UI                 UIConfig                    `yaml:"ui"`
+	DSP                DSPConfig                   `yaml:"dsp"`
+	LookupServices     LookupServicesConfig        `yaml:"lookup_services"`
+	MonitorDisplay     MonitorDisplayConfig        `yaml:"monitor_display"`
+	Bookmarks          []Bookmark                  `yaml:"bookmarks"`
+	Bands              []Band                      `yaml:"bands"`
+	Extensions         []string                    `yaml:"extensions"`
+	DefaultExtension   string                      `yaml:"default_extension,omitempty"`
 }
 
 // MonitorDisplayConfig contains settings for the optional Pimoroni Unicorn LED
@@ -424,7 +427,7 @@ type FrequencyGainRange struct {
 type SpectrumConfig struct {
 	Enabled bool                  `yaml:"enabled"`
 	Default SpectrumDefaultConfig `yaml:"default"`
-	// BinCount is the number of FFT bins across the full 0-30 MHz view — the
+	// BinCount is the number of FFT bins across the active instantaneous receiver view — the
 	// horizontal resolution of the spectrum and waterfall. Only 512 (low),
 	// 1024 (normal) and 2048 (high) are accepted; LoadConfig snaps anything
 	// else to the nearest of those and copies the result into Default.BinCount,
@@ -448,10 +451,9 @@ type SmoothingConfig struct {
 
 // SpectrumDefaultConfig contains default parameters for new spectrum channels.
 // These values are intentionally not settable directly via config.yaml — they are
-// derived in LoadConfig to ensure the display always covers exactly 0-30 MHz
-// (totalBandwidth = BinCount × BinBandwidth must equal 30,000,000 Hz).
+// derived in LoadConfig from receiver coverage and instantaneous sample rate.
 // BinCount is derived from the operator-facing spectrum.bin_count setting and
-// BinBandwidth is then computed as 30 MHz / BinCount.
+// BinBandwidth is then computed as receiver span / BinCount.
 type SpectrumDefaultConfig struct {
 	CenterFrequency uint64  `yaml:"-"`
 	BinCount        int     `yaml:"-"`
@@ -780,6 +782,23 @@ type SoundModemExtensionConfig struct {
 	MaxUsers int   `yaml:"max_users"` // Maximum concurrent users (0 = unlimited, default: 5)
 }
 
+// DigitalVoiceExtensionConfig contains settings for the receive-only DSD-FME
+// integration. Decoder mode arguments are selected from a fixed allowlist in
+// the digitalvoice package; no decryption/privacy key settings are exposed.
+type DigitalVoiceExtensionConfig struct {
+	Enabled    *bool  `yaml:"enabled"`     // Whether the extension is registered (default: true; nil = enabled)
+	BinaryPath string `yaml:"binary_path"` // DSD-FME executable path or command name (default: dsd-fme)
+	MaxUsers   int    `yaml:"max_users"`   // Maximum concurrent DSD-FME processes (default: 3)
+}
+
+// SignallingExtensionConfig contains settings for the receive-only
+// multimon-ng paging and signalling integration.
+type SignallingExtensionConfig struct {
+	Enabled    *bool  `yaml:"enabled"`     // Whether the extension is registered (default: true; nil = enabled)
+	BinaryPath string `yaml:"binary_path"` // multimon-ng executable path or command name (default: multimon-ng)
+	MaxUsers   int    `yaml:"max_users"`   // Maximum concurrent multimon-ng processes (default: 5)
+}
+
 // EiBiConfig contains settings for the EiBi shortwave broadcast schedule
 type EiBiConfig struct {
 	Enabled bool `yaml:"enabled"` // Enable/disable EiBi schedule fetching (default: false)
@@ -876,6 +895,11 @@ func LoadConfig(filename string) (*Config, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+
+	// Preserve the historical RX888 10 kHz-30 MHz installation when the new
+	// receiver section is absent, while allowing other SDRs to declare the
+	// actual range made available by their radiod instance.
+	config.Receiver.applyDefaults()
 
 	// Apply DSP filter defaults (nr2/rn2/nr4/dfnr enabled, bnr disabled)
 	// when the filters sub-section is absent from config.
@@ -1146,15 +1170,18 @@ func LoadConfig(filename string) (*Config, error) {
 		config.Admin.AllowedIPs = []string{"0.0.0.0/0"} // Default: allow all IPv4
 	}
 
-	// Set spectrum defaults if not specified.
+	// Set spectrum defaults from the receiver's instantaneous sampled range.
 	// Only bin_count is operator-facing; center frequency and bin bandwidth are
-	// derived, because changing them independently breaks the 0-30 MHz display
-	// (totalBandwidth = binCount × binBandwidth must equal 30 MHz).
+	// derived so narrow-band devices do not pretend their entire tuning range is
+	// visible at once.
+	minReceiverFrequency, maxReceiverFrequency := config.FrequencyRange()
+	minSpectrumFrequency, maxSpectrumFrequency := config.SpectrumRange()
+	receiverSpan := maxSpectrumFrequency - minSpectrumFrequency
 	if config.Spectrum.Default.CenterFrequency == 0 {
-		config.Spectrum.Default.CenterFrequency = 15000000 // 15 MHz center for 0-30 MHz coverage
+		config.Spectrum.Default.CenterFrequency = minSpectrumFrequency + receiverSpan/2
 	}
 
-	// Number of FFT bins across the 0-30 MHz view. Only 512 (low), 1024 (normal)
+	// Number of FFT bins across the full receiver view. Only 512 (low), 1024 (normal)
 	// and 2048 (high) are accepted; anything else snaps to the nearest of those so
 	// a typo in config.yaml can never produce a channel radiod will reject.
 	// The thresholds are geometric midpoints (√(512·1024) ≈ 724, √(1024·2048) ≈ 1448)
@@ -1175,10 +1202,10 @@ func LoadConfig(filename string) (*Config, error) {
 			rawBinCount, config.Spectrum.BinCount)
 	}
 
-	// Derived — never set directly. binCount × binBandwidth must equal exactly
-	// 30,000,000 Hz or the display stops covering 0-30 MHz.
+	// Derived — never set directly. binCount × binBandwidth equals the configured
+	// receiver coverage span.
 	config.Spectrum.Default.BinCount = config.Spectrum.BinCount
-	config.Spectrum.Default.BinBandwidth = 30000000.0 / float64(config.Spectrum.BinCount)
+	config.Spectrum.Default.BinBandwidth = float64(receiverSpan) / float64(config.Spectrum.BinCount)
 
 	if config.Spectrum.PollPeriodMs == 0 {
 		config.Spectrum.PollPeriodMs = 100 // 100ms default (10 Hz update rate)
@@ -1250,7 +1277,7 @@ func LoadConfig(filename string) (*Config, error) {
 	}
 
 	// Validate and clean up frequency gain ranges
-	config.Spectrum.validateFrequencyGainRanges()
+	config.Spectrum.validateFrequencyGainRanges(minReceiverFrequency, maxReceiverFrequency)
 
 	// Set DX cluster defaults if not specified
 	if config.DXCluster.Port == 0 {
@@ -1618,6 +1645,9 @@ func (c *AudioConfig) GetSampleRateForMode(mode string) int {
 
 // Validate checks if the configuration is valid
 func (c *Config) Validate() error {
+	if err := c.Receiver.Validate(); err != nil {
+		return err
+	}
 	if c.Radiod.StatusGroup == "" {
 		return fmt.Errorf("radiod.status_group is required")
 	}
@@ -2311,7 +2341,7 @@ func (irc *InstanceReportingConfig) IsInstanceReporter(ipStr string) bool {
 
 // validateFrequencyGainRanges validates and cleans up frequency gain ranges
 // Removes invalid ranges and logs warnings for user errors
-func (sc *SpectrumConfig) validateFrequencyGainRanges() {
+func (sc *SpectrumConfig) validateFrequencyGainRanges(minReceiverFrequency, maxReceiverFrequency uint64) {
 	if len(sc.GainDBFrequencyRanges) == 0 {
 		return
 	}
@@ -2327,11 +2357,10 @@ func (sc *SpectrumConfig) validateFrequencyGainRanges() {
 			continue
 		}
 
-		// Check if frequency range is reasonable (within HF range: 0-30 MHz)
-		const maxHFFreq = 30000000 // 30 MHz
-		if r.StartFreq > maxHFFreq {
-			fmt.Printf("Warning: Ignoring frequency gain range '%s': start_freq (%d Hz) exceeds maximum HF frequency (30 MHz)\n",
-				name, r.StartFreq)
+		// Ignore correction ranges that cannot overlap this receiver.
+		if r.EndFreq < minReceiverFrequency || r.StartFreq > maxReceiverFrequency {
+			fmt.Printf("Warning: Ignoring frequency gain range '%s': %d-%d Hz is outside receiver coverage %d-%d Hz\n",
+				name, r.StartFreq, r.EndFreq, minReceiverFrequency, maxReceiverFrequency)
 			continue
 		}
 

--- a/config/config.yaml.example
+++ b/config/config.yaml.example
@@ -39,8 +39,8 @@ admin:
   # Default tuning frequency for new visitors (Hz)
   # This is the frequency shown when a user first opens the web UI
   # Can be overridden per-link with the URL parameter: ?freq=7074000
-  # Valid range: 10000 (10 kHz) to 30000000 (30 MHz)
-  # Set to 0 (or omit) to use the built-in default of 14175000 (14.175 MHz - 20m USB calling frequency)
+  # Valid range: receiver.frequency_min_hz through receiver.frequency_max_hz
+  # Set to 0 (or omit) to use the midpoint of the configured receiver range
   default_frequency: 14175000
 
   # Default demodulation mode for new visitors
@@ -119,6 +119,41 @@ admin:
   # Default: ["ubersdr-claude"]
   widget_trusted_hosts:
     - "ubersdr-claude"
+
+# Receiver hardware/service capabilities
+#
+# Native KA9Q Radio driver values:
+#   airspy, airspyhf, bladerf, fobos, funcube, hackrf, hydrasdr,
+#   rtlsdr, rx888, sdrplay, sig_gen
+#
+# Use backend: external-radiod for a remote radiod instance or a separately
+# managed SoapySDR/vendor bridge that exposes KA9Q-compatible status/data groups.
+# The frequency range is the coverage intentionally made available by this
+# deployment (including any converter offset or front-end filtering), not a
+# marketing-limit guess made by the web application.
+receiver:
+  backend: "ka9q-radiod"
+  driver: "rx888"
+  device: "rx888"
+  description: "RX-888 wideband HF receiver"
+  sample_rate: 64800000
+  center_frequency: 0
+  frequency_min_hz: 10000
+  frequency_max_hz: 30000000
+  # Driver-specific KA9Q Radio settings. Values are copied to the generated
+  # driver section; consult the matching radiod example before enabling them.
+  options: {}
+  # Example for RTL-SDR:
+  # backend: "ka9q-radiod"
+  # driver: "rtlsdr"
+  # device: "rtlsdr"
+  # sample_rate: 2400000
+  # center_frequency: 145000000
+  # frequency_min_hz: 24000000
+  # frequency_max_hz: 1766000000
+  # options:
+  #   agc: "true"
+  #   bias: "no"
 
 # Radiod connection settings
 radiod:
@@ -2114,6 +2149,37 @@ soundmodem_extension:
   # controls the number of subprocesses running at any one time.
   # Set to 0 for unlimited users (not recommended for public instances).
   # Recommended: 3-5 depending on server capacity.
+  max_users: 5
+
+# ==============================================================================
+# Digital Voice Decoder Extension
+# ==============================================================================
+# Receive-only integration with DSD-FME for DMR, P25 Phase 1/2, NXDN48/96,
+# D-Star, YSF, M17, dPMR, ProVoice/EDACS, and X2-TDMA. The normal UberSDR NFM
+# stream is resampled from 24 kHz to DSD-FME's 48 kHz discriminator input.
+#
+# The extension uses a fixed protocol allowlist. It intentionally accepts no
+# encryption/privacy keys and no client-supplied DSD-FME command-line options.
+# Encrypted-call metadata can be shown, but encrypted voice is not decoded.
+digital_voice_extension:
+  # Set false to hide the decoder and prevent DSD-FME processes from starting.
+  enabled: true
+
+  # Executable path or command name. If only a command name is supplied it must
+  # be available in the ubersdr process PATH.
+  binary_path: "dsd-fme"
+
+  # One DSD-FME process is created per active listener.
+  max_users: 3
+
+# ==============================================================================
+# Paging and Signalling Decoder Extension
+# ==============================================================================
+# Receive-only integration with multimon-ng for POCSAG/FLEX paging, SAME/EAS,
+# DTMF, two-tone selective calling, and legacy telemetry formats.
+signalling_extension:
+  enabled: true
+  binary_path: "multimon-ng"
   max_users: 5
 
 # ==============================================================================

--- a/config/extensions.yaml.example
+++ b/config/extensions.yaml.example
@@ -35,6 +35,12 @@ extensions:
   # Sound Modem - Packet Decoder for AFSK/BFSK with IL2P Support
   - soundmodem
 
+  # Digital Voice - DMR, P25, NXDN, D-Star, YSF, M17, dPMR and ProVoice/EDACS via DSD-FME
+  - digitalvoice
+
+  # Paging & Signalling - POCSAG, FLEX, SAME/EAS, DTMF and two-tone formats via multimon-ng
+  - signalling
+
   # QRSS Grabber - Narrow-band spectrogram for reading very-slow CW (QRSS) beacons
   - qrss
 

--- a/cwskimmer.go
+++ b/cwskimmer.go
@@ -500,9 +500,9 @@ func (c *CWSkimmerClient) processLine(line string, spotHandlers []func(CWSkimmer
 
 	// Try to parse as CW spot
 	if spot, ok := c.parseCWSpot(line); ok {
-		// Filter spots: only process spots between 0 and 30 MHz
-		if spot.Frequency <= 0 || spot.Frequency > 30000000 {
-			// Silently discard spots outside the 0-30 MHz range
+		// Reject invalid values without imposing an HF-only ceiling. External
+		// skimmers may cover VHF/UHF and UI coverage is receiver-configured.
+		if spot.Frequency <= 0 {
 			return
 		}
 

--- a/decoder_config.go
+++ b/decoder_config.go
@@ -85,55 +85,10 @@ type ModeInfo struct {
 
 // GetModeInfo returns the mode information for a given decoder mode
 func GetModeInfo(mode DecoderMode) ModeInfo {
-	switch mode {
-	case ModeWSPR:
-		return ModeInfo{
-			CycleTime:        120 * time.Second,
-			TransmissionTime: 114 * time.Second,
-			DecoderCommand:   "wsprd",
-			DecoderArgs:      []string{"-f", "{freq}", "-C", "{depth}", "-w", "{file}"},
-			Preset:           "usb",
-			IsStreaming:      false,
-		}
-	case ModeFT8:
-		return ModeInfo{
-			CycleTime:        0, // No fixed cycles for streaming mode
-			TransmissionTime: 0,
-			DecoderCommand:   "jt9_wrapper",
-			DecoderArgs:      []string{"-m", "FT8", "-j", "{jt9_path}", "-s", "-d", "{depth}"},
-			Preset:           "usb",
-			IsStreaming:      true,
-		}
-	case ModeFT4:
-		return ModeInfo{
-			CycleTime:        0, // No fixed cycles for streaming mode
-			TransmissionTime: 0,
-			DecoderCommand:   "jt9_wrapper",
-			DecoderArgs:      []string{"-m", "FT4", "-j", "{jt9_path}", "-s", "-d", "{depth}"},
-			Preset:           "usb",
-			IsStreaming:      true,
-		}
-	case ModeJS8:
-		return ModeInfo{
-			CycleTime:        0, // No fixed cycles for streaming mode
-			TransmissionTime: 0,
-			DecoderCommand:   "js8",
-			DecoderArgs:      []string{"--stdin", "-d", "{depth}"},
-			Preset:           "usb",
-			IsStreaming:      true,
-		}
-	case ModeFT2:
-		return ModeInfo{
-			CycleTime:        0, // No fixed cycles for streaming mode
-			TransmissionTime: 0,
-			DecoderCommand:   "jt9_wrapper",
-			DecoderArgs:      []string{"-m", "FT2", "-j", "{jt9_path}", "-s", "-d", "{depth}"},
-			Preset:           "usb",
-			IsStreaming:      true,
-		}
-	default:
-		return ModeInfo{}
+	if plugin, ok := defaultDecoderPlugins.Lookup(mode); ok {
+		return plugin.ModeInfo()
 	}
+	return ModeInfo{}
 }
 
 // DecoderBandConfig represents a single band configuration for decoding

--- a/decoder_plugin.go
+++ b/decoder_plugin.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// DecoderPlugin describes one decoder integration. Implementations may use an
+// external process, a streaming service, or an in-process decoder; callers only
+// need the timing and input requirements exposed by ModeInfo.
+//
+// The existing built-ins are registered at startup. This registry deliberately
+// does not load arbitrary shared libraries: decoder integrations are compiled
+// into a trusted UberSDR build or supplied by a future out-of-process adapter.
+type DecoderPlugin interface {
+	ID() string
+	Mode() DecoderMode
+	ModeInfo() ModeInfo
+}
+
+type builtinDecoderPlugin struct {
+	id   string
+	mode DecoderMode
+	info ModeInfo
+}
+
+func (p builtinDecoderPlugin) ID() string         { return p.id }
+func (p builtinDecoderPlugin) Mode() DecoderMode  { return p.mode }
+func (p builtinDecoderPlugin) ModeInfo() ModeInfo { return p.info }
+
+// DecoderPluginRegistry is safe for startup-time registration and concurrent
+// reads by decoder workers. One plugin owns each DecoderMode.
+type DecoderPluginRegistry struct {
+	mu      sync.RWMutex
+	plugins map[DecoderMode]DecoderPlugin
+}
+
+func NewDecoderPluginRegistry() *DecoderPluginRegistry {
+	return &DecoderPluginRegistry{plugins: make(map[DecoderMode]DecoderPlugin)}
+}
+
+func (r *DecoderPluginRegistry) Register(plugin DecoderPlugin) error {
+	if plugin == nil || plugin.ID() == "" {
+		return fmt.Errorf("decoder plugin must have an ID")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if existing, ok := r.plugins[plugin.Mode()]; ok {
+		return fmt.Errorf("decoder mode %s is already owned by %s", plugin.Mode(), existing.ID())
+	}
+	r.plugins[plugin.Mode()] = plugin
+	return nil
+}
+
+func (r *DecoderPluginRegistry) Lookup(mode DecoderMode) (DecoderPlugin, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	plugin, ok := r.plugins[mode]
+	return plugin, ok
+}
+
+func (r *DecoderPluginRegistry) IDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.plugins))
+	for _, plugin := range r.plugins {
+		ids = append(ids, plugin.ID())
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+var defaultDecoderPlugins = newBuiltinDecoderPluginRegistry()
+
+func newBuiltinDecoderPluginRegistry() *DecoderPluginRegistry {
+	registry := NewDecoderPluginRegistry()
+	for _, plugin := range []DecoderPlugin{
+		builtinDecoderPlugin{id: "wspr", mode: ModeWSPR, info: ModeInfo{CycleTime: 120 * time.Second, TransmissionTime: 114 * time.Second, DecoderCommand: "wsprd", DecoderArgs: []string{"-f", "{freq}", "-C", "{depth}", "-w", "{file}"}, Preset: "usb"}},
+		builtinDecoderPlugin{id: "ft8", mode: ModeFT8, info: ModeInfo{DecoderCommand: "jt9_wrapper", DecoderArgs: []string{"-m", "FT8", "-j", "{jt9_path}", "-s", "-d", "{depth}"}, Preset: "usb", IsStreaming: true}},
+		builtinDecoderPlugin{id: "ft4", mode: ModeFT4, info: ModeInfo{DecoderCommand: "jt9_wrapper", DecoderArgs: []string{"-m", "FT4", "-j", "{jt9_path}", "-s", "-d", "{depth}"}, Preset: "usb", IsStreaming: true}},
+		builtinDecoderPlugin{id: "js8", mode: ModeJS8, info: ModeInfo{DecoderCommand: "js8", DecoderArgs: []string{"--stdin", "-d", "{depth}"}, Preset: "usb", IsStreaming: true}},
+		builtinDecoderPlugin{id: "ft2", mode: ModeFT2, info: ModeInfo{DecoderCommand: "jt9_wrapper", DecoderArgs: []string{"-m", "FT2", "-j", "{jt9_path}", "-s", "-d", "{depth}"}, Preset: "usb", IsStreaming: true}},
+	} {
+		if err := registry.Register(plugin); err != nil {
+			panic(err)
+		}
+	}
+	return registry
+}

--- a/decoder_plugin_test.go
+++ b/decoder_plugin_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestBuiltinDecoderPluginsPreserveModeInfo(t *testing.T) {
+	tests := []struct {
+		mode      DecoderMode
+		command   string
+		streaming bool
+	}{
+		{ModeWSPR, "wsprd", false},
+		{ModeFT8, "jt9_wrapper", true},
+		{ModeFT4, "jt9_wrapper", true},
+		{ModeJS8, "js8", true},
+		{ModeFT2, "jt9_wrapper", true},
+	}
+	for _, test := range tests {
+		info := GetModeInfo(test.mode)
+		if info.DecoderCommand != test.command || info.IsStreaming != test.streaming {
+			t.Fatalf("mode %s: got command=%q streaming=%v", test.mode, info.DecoderCommand, info.IsStreaming)
+		}
+	}
+}
+
+func TestDecoderPluginRegistryRejectsDuplicateMode(t *testing.T) {
+	registry := NewDecoderPluginRegistry()
+	plugin := builtinDecoderPlugin{id: "first", mode: ModeFT8}
+	if err := registry.Register(plugin); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.Register(builtinDecoderPlugin{id: "second", mode: ModeFT8}); err == nil {
+		t.Fatal("expected duplicate mode registration to fail")
+	}
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,45 @@ RUN go mod tidy
 # Build ka9q_ubersdr
 RUN make
 
+# Build a reproducible receive-only DSD-FME stack. The revisions are pinned so
+# a future upstream change cannot silently alter a published UltraSDR image.
+FROM ubuntu:24.04 AS dsd-builder
+
+ARG DSD_FME_REV=69d31151dd2d634cdc02aac4bff0e2a12c756ddb
+ARG MBELIB_REV=34adf9f054bc5650ace162a4917dcbc2cfa6102e
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    cmake \
+    git \
+    libcodec2-dev \
+    libncurses-dev \
+    libpulse-dev \
+    libsndfile1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone https://github.com/lwvmobile/mbelib.git \
+    && cd mbelib \
+    && git checkout "${MBELIB_REV}" \
+    && cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/local \
+    && cmake --build build --parallel \
+    && cmake --install build \
+    && ldconfig
+
+RUN git clone https://github.com/lwvmobile/dsd-fme.git \
+    && cd dsd-fme \
+    && git checkout "${DSD_FME_REV}" \
+    && cmake -S . -B build \
+         -DCMAKE_BUILD_TYPE=Release \
+         -DCMAKE_INSTALL_PREFIX=/usr/local \
+         -DCOLORS=OFF \
+         -DCOLORSLOGS=OFF \
+         -DPVC=ON \
+    && cmake --build build --parallel \
+    && cmake --install build
+
 # Runtime stage
 FROM ubuntu:24.04
 
@@ -58,6 +97,11 @@ RUN apt-get update && apt-get install -y \
     libfftw3-single3 \
     libfftw3-bin \
     libgfortran5 \
+    libcodec2-1.2 \
+    libncursesw6 \
+    libpulse0 \
+    libsndfile1 \
+    multimon-ng \
     && wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH} -O /usr/bin/yq \
     && chmod +x /usr/bin/yq \
     && wget https://github.com/madpsy/ubersdr-js8call/releases/download/latest/js8_${TARGETARCH} -O /usr/bin/js8 \
@@ -88,6 +132,13 @@ RUN apt-get update && apt-get install -y \
     && chmod +x /opt/freedv/freedv-ka9q \
     && rm /tmp/freedv.zip \
     && rm -rf /var/lib/apt/lists/*
+
+# Pinned DSD-FME and MBELib artifacts from the reproducible builder above.
+COPY --from=dsd-builder /usr/local/bin/dsd-fme /usr/local/bin/dsd-fme
+COPY --from=dsd-builder /usr/local/lib/libmbe.so* /usr/local/lib/
+RUN ldconfig \
+    && command -v dsd-fme \
+    && command -v multimon-ng
 
 # Set working directory
 WORKDIR /app
@@ -134,7 +185,9 @@ COPY --from=builder /build/geoip ./geoip
 
 # Copy entrypoint script
 COPY docker/entrypoint.sh /entrypoint.sh
+COPY docker/decoder-healthcheck.sh /usr/local/bin/ubersdr-decoder-healthcheck
 RUN chmod +x /entrypoint.sh
+RUN chmod +x /usr/local/bin/ubersdr-decoder-healthcheck
 
 # Expose default ports
 # 8080 - Web interface (as configured in config.yaml)

--- a/docker/decoder-healthcheck.sh
+++ b/docker/decoder-healthcheck.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+set -eu
+
+# Human- and automation-friendly inventory of decoder binaries in the image.
+# Exit non-zero with --required if the two core additions are unavailable.
+required=false
+if [ "${1:-}" = "--required" ]; then
+    required=true
+fi
+
+missing=0
+printf '%-20s %s\n' "decoder" "status"
+for decoder in dsd-fme multimon-ng jt9 wsprd js8 cw-decoder QtSoundModem freedv-ka9q; do
+    if command -v "$decoder" >/dev/null 2>&1; then
+        printf '%-20s %s\n' "$decoder" "available"
+    elif [ "$decoder" = "freedv-ka9q" ] && [ -x /opt/freedv/freedv-ka9q ]; then
+        printf '%-20s %s\n' "$decoder" "available"
+    else
+        printf '%-20s %s\n' "$decoder" "missing"
+        if [ "$decoder" = "dsd-fme" ] || [ "$decoder" = "multimon-ng" ]; then
+            missing=1
+        fi
+    fi
+done
+
+if [ "$required" = true ] && [ "$missing" -ne 0 ]; then
+    exit 1
+fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../../ka9q-radio
       dockerfile: docker/Dockerfile
-    image: ka9q-radio:latest
+    image: ${KA9Q_RADIO_IMAGE:-ka9q-radio:latest}
     container_name: ka9q-radio
     privileged: true
     restart: unless-stopped
@@ -46,7 +46,7 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    image: ka9q_ubersdr:latest
+    image: ${UBERSDR_IMAGE:-ka9q_ubersdr:latest}
     container_name: ka9q_ubersdr
     restart: unless-stopped
     init: true  # Enable tini init to reap zombie processes from background watchers

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -331,6 +331,9 @@ migrate_noisefloor_bands() {
 # Initialize configuration files
 initialize_configs
 
+echo "Decoder availability:"
+/usr/local/bin/ubersdr-decoder-healthcheck --required
+
 # Apply Docker networking fixes and admin password
 if [ -f "/app/config/config.yaml" ]; then
     fix_docker_networking

--- a/docs/DECODER_ARCHITECTURE.md
+++ b/docs/DECODER_ARCHITECTURE.md
@@ -1,0 +1,60 @@
+# Decoder architecture and expansion catalog
+
+UltraSDR separates decoders by the type and ownership of their input stream.
+This prevents a per-browser audio plugin from being stretched into a
+multi-megahertz, always-on IQ service.
+
+## Extension contracts
+
+| Contract | Lifetime | Input | Current integrations |
+| --- | --- | --- | --- |
+| Scheduled decoder plugin | Server-owned, timed | Recorded or streaming narrow audio | WSPR, FT8, FT4, FT2, JS8 |
+| Interactive audio extension | One process/state machine per listening session | PCM tapped before browser encoding | CW, RTTY/FSK, NAVTEX, WEFAX, SSTV, packet/AX.25, FreeDV, DRM, DMR/P25 family, paging/signalling |
+| Shared IQ service adapter | Server-owned, long-running | Named KA9Q IQ multicast channel plus metadata | Contract/design ready; service adapters below are the next implementation boundary |
+
+Audio extensions use a registry/factory interface and fixed, typed client
+parameters. External decoders are supervised, concurrency-limited processes.
+Arbitrary client-supplied executables and flags are prohibited.
+
+A shared IQ adapter must declare:
+
+- decoder ID and version;
+- center frequency, sample rate, sample format, and minimum usable bandwidth;
+- whether it owns a tuner or consumes an already-available IQ channel;
+- retune cost, restart policy, and CPU/memory limits;
+- structured outputs, health, and readiness state;
+- a fixed server-side command or container definition.
+
+The scheduler, not the decoder, must arbitrate tuners. It needs the number of
+receivers, instantaneous bandwidth, active center frequency, permissible RF
+range, dwell time, priority, and whether a decoder may be interrupted.
+
+## Priority shared-IQ adapters
+
+| Priority | Target | Reference service | Typical input | Output |
+| --- | --- | --- | --- | --- |
+| 1 | ADS-B / Mode S | readsb | 1090 MHz, ~2–2.4 Msps IQ | Aircraft/tracks, Beast/JSON |
+| 1 | 978 UAT | dump978-fa | 978 MHz, ~2 Msps IQ | Aircraft/weather JSON |
+| 1 | ISM sensors | rtl_433 | 433/868/915 MHz IQ | Typed sensor JSON |
+| 1 | AIS | AIS-catcher or rtl_ais | Marine VHF IQ | NMEA/JSON vessel reports |
+| 2 | ACARS | acarsdec | Airband IQ/audio | ACARS messages |
+| 2 | VDL Mode 2 | dumpvdl2 | Airband IQ | Structured VDL2 messages |
+| 2 | HFDL | dumphfdl | HF IQ | Aircraft/ground messages |
+| 2 | Broadcast FM RDS | redsea | WFM composite/baseband | RDS groups and station metadata |
+| 2 | Digital radio | dablin/welle.io, nrsc5 | VHF/FM-band IQ | Services, metadata, audio |
+| 3 | Satellite/weather | SatDump | Protocol-dependent wide IQ | Images, telemetry, products |
+| 3 | Occupancy/astronomy | GNU Radio or FFT workers | Wide IQ | Spectra, events, metrics |
+
+These tools are not all bundled into the main image: several require direct
+tuner ownership, large bandwidth, GPU/CPU budgets, or separate licenses and
+data-retention decisions. The supported deployment pattern is one container
+per shared decoder, attached to a server-created KA9Q IQ channel. This also
+avoids multiple containers fighting over the same USB device.
+
+## Definition of done for a new adapter
+
+An adapter is “supported” only when it has a pinned container/tool version, a
+typed configuration schema, health/readiness reporting, recorded-IQ fixtures,
+structured output tests, resource limits, restart behavior, Web UI display,
+and hardware-in-the-loop results for at least one representative receiver.
+Listing a protocol in this catalog alone does not claim operational support.

--- a/docs/DIGITAL_VOICE.md
+++ b/docs/DIGITAL_VOICE.md
@@ -1,0 +1,104 @@
+# Digital voice decoding
+
+UberSDR provides a receive-only digital voice extension backed by
+[DSD-FME](https://github.com/lwvmobile/dsd-fme). It is separate from the
+scheduled weak-signal decoder subsystem because DMR and similar protocols are
+continuous, listener-selected audio decoders rather than cycle-based FT8/WSPR
+jobs.
+
+## Supported profiles
+
+| Profile | DSD-FME mode | Typical occupied bandwidth | Notes |
+| --- | --- | ---: | --- |
+| Auto | `-fa` | 12 kHz | Automatic DMR, P25, YSF, D-Star, and X2-TDMA detection |
+| DMR | `-fs` | 7–12 kHz | Tier II base/mobile and simplex; two time slots |
+| P25 Phase 1 | `-f1` | 12 kHz | Conventional FDMA |
+| P25 Phase 2 | `-f2` | 12 kHz | TDMA traffic channel; some systems need trunking context not yet supplied by UberSDR |
+| NXDN48 / IDAS | `-fi` | 7 kHz | 6.25 kHz channel |
+| NXDN96 | `-fn` | 12 kHz | 12.5 kHz channel |
+| D-Star | `-fd` | 12 kHz | Explicit selection required |
+| YSF | `-fy` | 12 kHz | Yaesu System Fusion |
+| M17 | `-fz` | 12 kHz | Explicit selection required |
+| dPMR | `-fm` | 7 kHz | Explicit selection required |
+| ProVoice | `-fp` | up to 24 kHz | Conventional ProVoice |
+| EDACS / ProVoice | `-fh` | up to 24 kHz | Single-frequency control/voice decode only |
+| X2-TDMA | `-fx` | 12 kHz | Explicit selection required |
+
+This first integration handles a tuned conventional channel. Full trunk
+following needs a separate channel-control service that can coordinate a
+control-channel decoder, channel maps, talkgroup policy, and one or more
+receiver VFOs. That belongs behind the same plugin boundary but is not implied
+by the single-listener extension.
+
+## Signal path
+
+```text
+SDR hardware -> radiod NFM demodulator -> 24 kHz mono audio tap
+             -> stateful 48 kHz resampler -> DSD-FME stdin
+             -> loopback UDP decoded PCM -> WebSocket -> browser playback
+             -> stderr event parser       -> WebSocket -> event panel
+```
+
+DSD-FME expects 48 kHz, 16-bit, mono discriminator/baseband audio. UberSDR's
+standard NFM preset supplies 24 kHz mono PCM, so the extension resamples it to
+48 kHz while preserving phase across network packet boundaries.
+
+The decoded-audio UDP socket binds to `127.0.0.1` on an ephemeral port. It is
+not exposed on the network. Each listener receives a separate supervised
+DSD-FME process and loopback socket.
+
+## Installation and configuration
+
+Build or install DSD-FME using its upstream instructions and make the
+`dsd-fme` executable available to the UberSDR process. Then enable the server
+extension:
+
+```yaml
+digital_voice_extension:
+  enabled: true
+  binary_path: "dsd-fme"
+  max_users: 3
+```
+
+Also add the browser extension to `config/extensions.yaml`:
+
+```yaml
+extensions:
+  - digitalvoice
+```
+
+An absolute `binary_path` can be used when DSD-FME is installed outside the
+service `PATH`. Each active listener creates a decoder process, so public
+instances should use a conservative `max_users` limit.
+
+## Clear reception only
+
+UberSDR does not accept privacy or encryption keys, key files, arbitrary
+DSD-FME arguments, or client-selected executables. Protocol selection maps to a
+fixed allowlist of decoding switches in
+`audio_extensions/digitalvoice/profiles.go`.
+
+DSD-FME may identify an encrypted call in its event output. UberSDR marks that
+event as encrypted, and its UI labels the audio as suppressed. The integration
+does not provide a decryption workflow.
+
+## Current limitations and next steps
+
+- A clean NFM discriminator/baseband signal is required. Voice-emphasized or
+  aggressively filtered audio can prevent symbol synchronization.
+- Auto mode is intentionally limited to the protocols DSD-FME can reliably
+  auto-detect. NXDN, M17, dPMR, ProVoice, and EDACS use explicit profiles;
+  explicit D-Star, YSF, and X2-TDMA profiles remain available when auto
+  detection is undesirable.
+- P25 Phase 2 traffic channels can require WACN/SYSID/NAC context. The public
+  extension does not yet accept those advanced fields.
+- Trunk following, talkgroup allow/block lists, channel maps, and multi-VFO
+  coordination are planned as a separate privileged server-side controller.
+- Metadata normalization is best-effort because DSD-FME currently exposes
+  human-readable console events rather than a stable machine-readable event
+  API. The original line is retained in every event.
+
+The package has unit coverage for the protocol allowlist, safe command
+construction, streaming resampler continuity, and common event parsing. A
+hardware-in-the-loop test should feed known clear-air recordings for every
+profile before a deployment claims RF-level interoperability.

--- a/docs/SDR_EXPANSION_PLAN.md
+++ b/docs/SDR_EXPANSION_PLAN.md
@@ -1,0 +1,69 @@
+# SDR expansion plan
+
+## Baseline findings
+
+UberSDR is a Go web, session, and monitoring application rather than a hardware driver. A single `RadiodController` communicates with KA9Q `radiod` over multicast, and sessions are expressed as radiod channels identified by SSRC. The included receiver template is RX888-specific. The Docker deployment grants USB access only to the KA9Q container, so device support today is defined by that container's KA9Q Radio build and configuration.
+
+The decoder scheduler consumes demodulated PCM/WAV audio from radiod. Its built-in modes are WSPR, FT8, FT4, JS8, and FT2; mode selection, binary paths, CLI arguments, parser expectations, reporting, and lifecycle policy are currently coupled to a `DecoderMode` enum.
+
+This is a strong architecture for one wideband KA9Q receiver, but it assumes a multicast KA9Q control plane, radiod presets, a single source namespace, and a small fixed decoder list.
+
+## Target architecture
+
+Keep the existing session API stable while adding a receiver layer underneath it:
+
+1. **SDR backend**: owns discovery, opening a source, tuning, gain, clock state, and a capability declaration (frequency limits, sample rate, channels, IQ, GPSDO).
+2. **source adapter**: normalizes a device or network source to timestamped complex IQ with explicit sample format, rate, center frequency, and discontinuity events.
+3. **channel engine**: makes demodulated audio, spectrum tiles, and optional IQ taps from normalized IQ. KA9Q radiod remains the first channel-engine adapter during migration.
+4. **monitor scheduler**: allocates tuners/bandwidth using priority, dwell time, CPU budget, and recording policy; it must never assume that every frequency is visible from one capture.
+5. **decoder plugins**: declare accepted input, timing/window needs, parser, result schema, and reporting targets. Plugins run as trusted built-ins or out-of-process adapters with a versioned RPC protocol—never arbitrary in-process downloads.
+
+The initial code adds a capability-oriented `SDRBackendRegistry` with `ka9q-radiod` registered, and moves the five built-in decoder definitions behind a `DecoderPluginRegistry`. Existing configuration and behavior remain unchanged.
+
+## Priority hardware families
+
+| Priority | Families | Why / first path |
+| --- | --- | --- |
+| P0 | KA9Q Radio with RX888/USRP-class wideband frontends | Preserve and document the production path; supports wide HF monitoring now. |
+| P1 | RTL-SDR v3/v4 and compatible rtl_tcp | Lowest-cost receive-only deployment; use a supervised `rtl_tcp`/Soapy adapter first for portability. |
+| P1 | Airspy HF+ and Airspy R2/Mini | Strong HF/VHF performance; implement through SoapySDR or native sidecar where its controls matter. |
+| P1 | SDRplay RSP family | Broad coverage and popular hardware; sidecar isolates vendor API/licensing and USB permissions. |
+| P2 | HackRF One, LimeSDR, bladeRF | Wideband experiments and transmit-capable hardware; receive-only initially, with explicit TX interlocks later. |
+| P2 | Ettus USRP, ADALM-Pluto, Red Pitaya | Network/high-rate and synchronized deployments; use UHD/IIO sidecars and expose clock/PTP/GPSDO state. |
+| P2 | KiwiSDR / OpenWebRX / SpyServer / rtl_tcp remote sources | Enables geographically distributed monitoring without local USB access. |
+
+Use SoapySDR where it provides a reliable common denominator, but retain backend-specific sidecars for timing, bias tee, preselectors, coherent channels, and device-specific calibration.
+
+## Monitoring and decoding roadmap
+
+### Phase 1 — HF and existing audio pipeline
+
+- Migrate WSPR, FT8, FT4, JS8, and FT2 to registered plugins (started).
+- Add AM broadcast/utility monitoring, CW/RBN, NAVTEX, weather fax, DRM, FreeDV, and digital audio extension results to a common event schema.
+- Add receiver capability checks to band/decoder validation and operator-visible coverage gaps.
+
+### Phase 2 — VHF/UHF spectrum monitoring
+
+- Add narrowband FM/AM/SSB monitoring and signal classification.
+- Add ADS-B (1090 MHz), ACARS/VDL2, AIS (161.975/162.025 MHz), APRS (144.39 MHz regional), NOAA APT, DMR, P25, NXDN, dPMR, TETRA, and pager workflows where lawful.
+- Keep trunked/digital-voice handling as opt-in plugins with local legal and access controls; do not build interception or decryption features.
+
+### Phase 3 — microwave/satellite and distributed sensing
+
+- Add 433/868/915 MHz ISM telemetry, LoRaWAN gateways, GOES/HRPT, Inmarsat AERO, satellite beacon tracking, and direction/TDOA workflows where hardware timing supports them.
+- Add multi-receiver scheduling, health scoring, calibrated occupancy maps, recordings with provenance, and an event bus for alerts.
+
+## Delivery sequence
+
+1. Add a `receiver.backend` configuration block and select `ka9q-radiod` by default.
+2. Introduce a sidecar protocol for direct-IQ sources; ship `rtl_tcp` and SoapySDR reference adapters.
+3. Adapt the channel engine so radiod and direct-IQ adapters both satisfy the existing session/spectrum contracts.
+4. Add plugin manifests, an out-of-process decoder runner, resource limits, and normalized events.
+5. Add monitoring schedules, storage quotas, receiver health/clock metrics, and UI coverage reporting.
+
+## Compatibility and safety rules
+
+- Preserve the current radiod multicast + SSRC behavior until the direct-IQ path reaches feature parity.
+- Treat frequency, gain, bandwidth, sample format, and timestamps as explicit metadata; do not infer them from a decoder mode.
+- Default new device backends to receive-only. Any future transmit support requires separate credentials, physical/firmware interlocks, band-plan enforcement, and explicit operator enablement.
+- Enforce per-plugin CPU, memory, runtime, output-size, and network permissions. Record only operator-authorized bands and retention periods.

--- a/docs/SDR_EXPANSION_PLAN.md
+++ b/docs/SDR_EXPANSION_PLAN.md
@@ -18,7 +18,12 @@ Keep the existing session API stable while adding a receiver layer underneath it
 4. **monitor scheduler**: allocates tuners/bandwidth using priority, dwell time, CPU budget, and recording policy; it must never assume that every frequency is visible from one capture.
 5. **decoder plugins**: declare accepted input, timing/window needs, parser, result schema, and reporting targets. Plugins run as trusted built-ins or out-of-process adapters with a versioned RPC protocol—never arbitrary in-process downloads.
 
-The initial code adds a capability-oriented `SDRBackendRegistry` with `ka9q-radiod` registered, and moves the five built-in decoder definitions behind a `DecoderPluginRegistry`. Existing configuration and behavior remain unchanged.
+The initial implementation adds a capability-oriented `SDRBackendRegistry`
+with native and external-radiod paths, a catalog covering every receive driver
+currently exposed by KA9Q Radio, configuration-driven RF coverage, and a
+radiod configuration preview generator. It also moves the five built-in
+decoder definitions behind a `DecoderPluginRegistry`. Omitting the new receiver
+block preserves the existing RX-888/10 kHz–30 MHz behavior.
 
 ## Priority hardware families
 
@@ -55,11 +60,12 @@ Use SoapySDR where it provides a reliable common denominator, but retain backend
 
 ## Delivery sequence
 
-1. Add a `receiver.backend` configuration block and select `ka9q-radiod` by default.
-2. Introduce a sidecar protocol for direct-IQ sources; ship `rtl_tcp` and SoapySDR reference adapters.
-3. Adapt the channel engine so radiod and direct-IQ adapters both satisfy the existing session/spectrum contracts.
-4. Add plugin manifests, an out-of-process decoder runner, resource limits, and normalized events.
-5. Add monitoring schedules, storage quotas, receiver health/clock metrics, and UI coverage reporting.
+1. Add a `receiver.backend` configuration block and select `ka9q-radiod` by default. **Implemented.**
+2. Catalog all current KA9Q receive drivers and add a generic externally managed radiod/Soapy path. **Implemented.**
+3. Introduce a versioned sidecar protocol for direct-IQ sources; ship `rtl_tcp` and SoapySDR reference adapters.
+4. Adapt the channel engine so radiod and direct-IQ adapters both satisfy the existing session/spectrum contracts.
+5. Add plugin manifests, an out-of-process decoder runner, resource limits, and normalized events.
+6. Add monitoring schedules, storage quotas, receiver health/clock metrics, and UI coverage reporting.
 
 ## Compatibility and safety rules
 

--- a/docs/SDR_HARDWARE.md
+++ b/docs/SDR_HARDWARE.md
@@ -1,0 +1,158 @@
+# SDR hardware support
+
+UberSDR uses KA9Q Radio's `radiod` as its channel, spectrum, and multicast
+engine. Hardware support therefore has two layers:
+
+1. UberSDR describes the active receiver, validates its advertised RF coverage,
+   and stops clients from tuning outside that coverage.
+2. `radiod` or an external bridge opens the physical/network SDR and publishes
+   KA9Q-compatible status and sample groups.
+
+This boundary lets the web and decoder layers support HF, VHF, UHF, and
+microwave deployments without embedding every vendor SDK into the web server.
+It also keeps USB failures and high-rate IQ processing out of user sessions.
+
+## Supported paths
+
+| Family | `receiver.driver` | Integration path | Extra runtime dependency |
+| --- | --- | --- | --- |
+| RX-888 MkII/compatible | `rx888` | Native KA9Q Radio driver | FX3 firmware/libusb as required by the radiod build |
+| RTL-SDR compatible | `rtlsdr` | Native KA9Q Radio driver | `librtlsdr` |
+| Airspy R2/Mini | `airspy` | Native KA9Q Radio driver | `libairspy` |
+| Airspy HF+ family | `airspyhf` | Native KA9Q Radio driver | `libairspyhf` |
+| SDRplay RSP family | `sdrplay` | Native KA9Q Radio driver | SDRplay API matching the radiod build |
+| HackRF family | `hackrf` | Native KA9Q Radio driver | `libhackrf` |
+| Nuand bladeRF | `bladerf` | Native KA9Q Radio driver | `libbladeRF` |
+| RigExpert Fobos | `fobos` | Native KA9Q Radio driver | Fobos library |
+| FUNcube Dongle Pro+ | `funcube` | Native KA9Q Radio driver | ALSA/USB HID support |
+| HydraSDR | `hydrasdr` | Native KA9Q Radio driver | HydraSDR library |
+| LimeSDR, USRP, PlutoSDR, Red Pitaya, remote receivers, and future devices | bridge-defined | `external-radiod` | A separately managed KA9Q-compatible bridge, commonly backed by SoapySDR or the vendor API |
+
+The profile catalog describes drivers available in current KA9Q Radio source.
+A particular binary can contain fewer optional drivers if it was built without
+their development libraries. UberSDR cannot make a missing vendor library or
+kernel USB permission appear; verify the driver in the deployed radiod image.
+
+## Receiver configuration
+
+The `receiver` block is the source of truth for browser and API frequency
+validation:
+
+```yaml
+receiver:
+  backend: ka9q-radiod
+  driver: rtlsdr
+  device: rtlsdr
+  description: VHF/UHF receiver
+  sample_rate: 2400000
+  center_frequency: 145000000
+  frequency_min_hz: 24000000
+  frequency_max_hz: 1766000000
+  options:
+    agc: "true"
+    bias: "no"
+```
+
+Set the range to frequencies the *deployment* can actually serve. Account for
+direct-sampling modes, up/down-converters, preselectors, antenna switching, and
+regional restrictions. Device headline limits are not reliable service limits.
+UberSDR accepts both endpoints as tunable.
+
+When `sample_rate` is smaller than that tunable range, the initial spectrum
+uses one sample-rate-wide window around `center_frequency`; it does not pretend
+that the entire tunable range is visible simultaneously. The native UI can pan
+and retune within the wider coverage. WebSDR/Kiwi compatibility pages advertise
+that instantaneous window because their legacy single-band coordinate systems
+cannot separately express tunable range and current capture bandwidth.
+Noise-floor bands outside that instantaneous window are skipped with a startup
+log entry. Monitoring disjoint bands on one narrow device requires the planned
+dwell/retune scheduler; configuring a large tuning range alone cannot make
+those frequencies simultaneous.
+
+The legacy behavior is preserved when the block is omitted:
+
+```yaml
+receiver:
+  backend: ka9q-radiod
+  driver: rx888
+  frequency_min_hz: 10000
+  frequency_max_hz: 30000000
+```
+
+For a receiver service managed outside the UberSDR deployment:
+
+```yaml
+receiver:
+  backend: external-radiod
+  driver: soapy
+  description: Remote SoapySDR bridge
+  frequency_min_hz: 500000
+  frequency_max_hz: 6000000000
+
+radiod:
+  status_group: remote-status.local:5006
+  data_group: remote-pcm.local:5004
+  interface: eth0
+```
+
+`external-radiod` intentionally does not validate a driver name. The bridge is
+responsible for discovery, sample-format conversion, time/discontinuity
+metadata, tuning, gain controls, and publishing the KA9Q multicast protocol.
+
+## Generating a native radiod configuration
+
+Authenticated administrators can inspect the catalog:
+
+```text
+GET /admin/receiver-profiles
+```
+
+The response includes the active receiver, backend capabilities, and native
+driver profiles. To preview a minimal radiod configuration without changing
+files or restarting a service, post a receiver JSON object to the same endpoint:
+
+```text
+POST /admin/receiver-profiles
+Content-Type: application/json
+```
+
+Review the preview against the matching KA9Q Radio example and the installed
+driver version. The existing `/admin/radiod-config` endpoint remains the
+explicit apply step.
+
+## What “all SDRs” means in practice
+
+No finite application can ship or test every SDR, firmware revision, vendor
+SDK, FPGA image, and network protocol. The supported contract is therefore:
+
+- native profiles for every receiver driver currently exposed by KA9Q Radio;
+- a generic external receiver-service adapter for everything else;
+- configuration-driven RF coverage throughout session and spectrum creation;
+- driver options that can pass through without a web-server release;
+- receive-only operation. Transmit controls are deliberately outside this
+  abstraction and require a separate safety and authorization design.
+
+The primary web UI, server WebSockets, admin bookmark/band paths, WebSDR, and
+Kiwi compatibility layers consume the configured ranges. Some standalone
+clients under `clients/` still carry their own legacy HF validation constants;
+they should migrate to the receiver fields returned by `/api/description`
+before being advertised for non-HF deployments.
+
+## Decoder and monitoring priorities
+
+The decoder registry allows additional audio decoders without extending a
+central mode switch. Immediate monitoring targets by coverage are:
+
+| Coverage | Priority targets |
+| --- | --- |
+| LF/HF | WSPR, FT8/FT4/FT2, JS8, CW/RBN, NAVTEX, weather fax, DRM, FreeDV |
+| VHF air/marine | AM voice, ACARS/VDL2, AIS, NOAA APT |
+| VHF/UHF land/mobile | NFM, APRS, paging, DMR/P25/NXDN metadata where lawful |
+| 1090 MHz | ADS-B/Mode S |
+| 433/868/915 MHz | ISM occupancy and operator-authorized telemetry |
+| L/S band and above | satellite beacons, AERO/HRPT/GOES workflows, hardware permitting |
+
+Wide-range hardware is not wide-instantaneous-bandwidth hardware. A monitor
+scheduler must eventually model tuner count, current center frequency,
+instantaneous bandwidth, retune cost, dwell time, and decoder priority before
+multiple disjoint bands can be monitored honestly.

--- a/docs/SIGNALLING.md
+++ b/docs/SIGNALLING.md
@@ -1,0 +1,50 @@
+# Paging and signalling decoder
+
+UltraSDR includes a receive-only `multimon-ng` integration for common analogue
+signalling carried in demodulated NFM audio. It runs inside the normal Docker
+image and appears as **Paging & Signalling** in the decoder panel.
+
+## Decoder profiles
+
+| Profile | Formats |
+| --- | --- |
+| Paging | POCSAG 512/1200/2400 and FLEX |
+| POCSAG | POCSAG 512/1200/2400 with alphanumeric output |
+| FLEX | Motorola FLEX paging |
+| SAME / EAS | Emergency Alert System SAME headers |
+| DTMF | Dual-tone multi-frequency digits |
+| Two-tone | ZVEI1/2/3, DZVEI, PZVEI, CCIR, EEA, and EIA |
+| Legacy telemetry | UFSK1200, CLIPFSK, and FMSFSK |
+| Auto / all | All formats above |
+
+The server resamples the selected mono audio channel to the 22,050 Hz raw PCM
+input expected by `multimon-ng`. The Web UI automatically selects NFM and a
+12–15 kHz receive bandwidth before attaching the decoder.
+
+## Configuration
+
+```yaml
+signalling_extension:
+  enabled: true
+  binary_path: "multimon-ng"
+  max_users: 5
+```
+
+The Docker image installs `multimon-ng`. For a native deployment, install it
+with the operating-system package manager or set `binary_path` to an absolute
+executable path. Each listener owns one process, so set a conservative
+`max_users` value on public receivers.
+
+Clients select only a fixed server-side profile. They cannot supply command
+arguments, executable paths, or additional demodulator names.
+
+## Practical limits
+
+- Paging and selective-calling traffic can contain personal or operational
+  information. Operators are responsible for local monitoring and privacy law.
+- Decoding requires clean discriminator/baseband audio. Voice filtering,
+  squelch clipping, or incorrect deviation reduces reliability.
+- FLEX support depends on the `multimon-ng` version packaged by the target
+  distribution.
+- The integration displays decoder lines as received and does not attempt to
+  interpret, forward, archive, or alert on message content.

--- a/dxcluster.go
+++ b/dxcluster.go
@@ -498,8 +498,8 @@ func (c *DXClusterClient) processLine(line string) {
 
 	// Try to parse as DX spot
 	if spot, ok := c.parseDXSpot(line); ok {
-		// Filter spots: only process spots between 0 and 30 MHz
-		if spot.Frequency <= 0 || spot.Frequency > 30000000 {
+		// DX clusters also carry VHF, UHF, and microwave spots.
+		if spot.Frequency <= 0 {
 			return
 		}
 

--- a/kiwi_websocket.go
+++ b/kiwi_websocket.go
@@ -521,9 +521,11 @@ func (kwsh *KiwiWebSocketHandler) HandleKiwiStatus(w http.ResponseWriter, r *htt
 	status.WriteString("status=active\n")
 	status.WriteString("offline=no\n")
 
-	// Name in KiwiSDR directory format: "0-30 MHz SDR, <callsign>, <location>"
+	minFrequency, maxFrequency := kwsh.config.SpectrumRange()
+	rangeDescription := fmt.Sprintf("%.3f-%.3f MHz SDR",
+		float64(minFrequency)/1_000_000, float64(maxFrequency)/1_000_000)
 	{
-		nameParts := []string{"0-30 MHz SDR"}
+		nameParts := []string{rangeDescription}
 		if kwsh.config.Admin.Callsign != "" {
 			nameParts = append(nameParts, kwsh.config.Admin.Callsign)
 		}
@@ -545,8 +547,7 @@ func (kwsh *KiwiWebSocketHandler) HandleKiwiStatus(w http.ResponseWriter, r *htt
 		status.WriteString(fmt.Sprintf("op_email=%s\n", publicEmail))
 	}
 
-	// Frequency range (0-30 MHz in Hz)
-	status.WriteString("bands=0-30000000\n")
+	status.WriteString(fmt.Sprintf("bands=%d-%d\n", minFrequency, maxFrequency))
 	status.WriteString("freq_offset=0.000\n")
 	status.WriteString("mode=rx4_wf4\n")
 
@@ -1139,9 +1140,10 @@ func (kc *kiwiConn) handleSetCommand(command string) {
 		kc.zoom = zoom
 		kc.mu.Unlock()
 
-		// Calculate bin_bandwidth from zoom level
-		// Full span = 30 MHz, zoom divides by 2^zoom, 1024 bins displayed
-		fullSpanKHz := 30000.0
+		// Calculate bin bandwidth from the active receiver span.
+		minFrequency, maxFrequency := kc.config.SpectrumRange()
+		minFrequencyKHz := float64(minFrequency) / 1000
+		fullSpanKHz := float64(maxFrequency-minFrequency) / 1000
 		spanKHz := fullSpanKHz / math.Pow(2, float64(zoom))
 		requestedBinBandwidth := (spanKHz * 1000) / 1024 // Hz per bin at this zoom level
 
@@ -1161,8 +1163,8 @@ func (kc *kiwiConn) handleSetCommand(command string) {
 			cfKHz, _ := strconv.ParseFloat(cfStr, 64)
 			freq = uint64(cfKHz * 1000)
 			// Calculate xBin from center frequency (at max zoom resolution)
-			// freq_to_bin: bin = (freq / bandwidth) * max_bins
-			centerBin := (cfKHz / fullSpanKHz) * float64(maxBins)
+			// freq_to_bin: bin = ((freq - minimum) / bandwidth) * max_bins
+			centerBin := ((cfKHz - minFrequencyKHz) / fullSpanKHz) * float64(maxBins)
 			// Calculate bins at current zoom: bins_at_zoom(zoom) = wf_fft_size << (zoom_levels_max - zoom)
 			binsAtCurrentZoom := 1024 << uint(maxZoom-zoom)
 			// xBin is the start position, so it's center minus half the window
@@ -1185,25 +1187,19 @@ func (kc *kiwiConn) handleSetCommand(command string) {
 
 			// Convert bin to frequency: freq = (bin / max_bins) * bandwidth
 			totalBandwidthHz := fullSpanKHz * 1000.0
-			freq = uint64((centerBin / float64(maxBins)) * totalBandwidthHz)
+			freq = minFrequency + uint64((centerBin/float64(maxBins))*totalBandwidthHz)
 		} else {
-			// No cf or start provided, use current center (15 MHz)
-			freq = 15000000
+			// No cf or start provided, use the configured receiver center.
+			freq = minFrequency + (maxFrequency-minFrequency)/2
 			xBin = 0
 		}
 
-		// Clamp center frequency to valid HF range (10 kHz – 30 MHz).
-		// The KiwiSDR hardware physically cannot tune outside 0-30 MHz, but
-		// a malformed or out-of-range x_bin / cf value from the client can
-		// produce a calculated frequency well beyond that.  Clamp rather than
-		// reject so the waterfall stays usable at the boundary.
-		const minSpectrumFreq = 10000    // 10 kHz
-		const maxSpectrumFreq = 30000000 // 30 MHz
-		if freq < minSpectrumFreq {
-			freq = minSpectrumFreq
+		// Clamp malformed client coordinates to receiver coverage.
+		if freq < minFrequency {
+			freq = minFrequency
 		}
-		if freq > maxSpectrumFreq {
-			freq = maxSpectrumFreq
+		if freq > maxFrequency {
+			freq = maxFrequency
 		}
 
 		// Always use 1024 bins (matching real KiwiSDR FPGA hardware behaviour).
@@ -1766,7 +1762,12 @@ func (kc *kiwiConn) sendInitMessages() {
 		rxTitle = kc.config.Admin.Callsign + " - " + kc.config.Admin.Name
 	}
 
-	cfgJSON := `{"passbands":{"am":{"lo":-4900,"hi":4900},"amn":{"lo":-2500,"hi":2500},"amw":{"lo":-6000,"hi":6000},"sam":{"lo":-4900,"hi":4900},"sal":{"lo":-4900,"hi":0},"sau":{"lo":0,"hi":4900},"sas":{"lo":-4900,"hi":4900},"qam":{"lo":-4900,"hi":4900},"drm":{"lo":-5000,"hi":5000},"lsb":{"lo":-2400,"hi":-300},"lsn":{"lo":-2100,"hi":-300},"usb":{"lo":300,"hi":2400},"usn":{"lo":300,"hi":2100},"cw":{"lo":-400,"hi":400},"cwn":{"lo":-250,"hi":250},"nbfm":{"lo":-6000,"hi":6000},"nnfm":{"lo":-5000,"hi":5000},"iq":{"lo":-10000,"hi":10000}},"rx_grid":"` + gridSquare + `","rx_gps":"` + gpsCoords + `","rx_antenna":"` + kc.config.Admin.Antenna + `","index_html_params":{"PAGE_TITLE":"KiwiSDR","RX_PHOTO_HEIGHT":350,"RX_PHOTO_TITLE_HEIGHT":70,"RX_PHOTO_TITLE":"","RX_PHOTO_DESC":"","RX_TITLE":"` + rxTitle + `","RX_LOC":"` + kc.config.Admin.Location + `","RX_QRA":"` + gridSquare + `","RX_ASL":` + fmt.Sprintf("%d", kc.config.Admin.ASL) + `,"RX_GMAP":""},"owner_info":"` + ownerInfo + `","init":{"freq":7020,"mode":"cw","zoom":0,"max_dB":-10,"min_dB":-110},"waterfall_cal":-3,"waterfall_min_dB":-110,"waterfall_max_dB":-10,"snr_meas_interval_hrs":0}`
+	minFrequency, maxFrequency := kc.config.SpectrumRange()
+	initialFrequency := kc.config.Admin.DefaultFrequency
+	if initialFrequency < minFrequency || initialFrequency > maxFrequency {
+		initialFrequency = minFrequency + (maxFrequency-minFrequency)/2
+	}
+	cfgJSON := `{"passbands":{"am":{"lo":-4900,"hi":4900},"amn":{"lo":-2500,"hi":2500},"amw":{"lo":-6000,"hi":6000},"sam":{"lo":-4900,"hi":4900},"sal":{"lo":-4900,"hi":0},"sau":{"lo":0,"hi":4900},"sas":{"lo":-4900,"hi":4900},"qam":{"lo":-4900,"hi":4900},"drm":{"lo":-5000,"hi":5000},"lsb":{"lo":-2400,"hi":-300},"lsn":{"lo":-2100,"hi":-300},"usb":{"lo":300,"hi":2400},"usn":{"lo":300,"hi":2100},"cw":{"lo":-400,"hi":400},"cwn":{"lo":-250,"hi":250},"nbfm":{"lo":-6000,"hi":6000},"nnfm":{"lo":-5000,"hi":5000},"iq":{"lo":-10000,"hi":10000}},"rx_grid":"` + gridSquare + `","rx_gps":"` + gpsCoords + `","rx_antenna":"` + kc.config.Admin.Antenna + `","index_html_params":{"PAGE_TITLE":"KiwiSDR","RX_PHOTO_HEIGHT":350,"RX_PHOTO_TITLE_HEIGHT":70,"RX_PHOTO_TITLE":"","RX_PHOTO_DESC":"","RX_TITLE":"` + rxTitle + `","RX_LOC":"` + kc.config.Admin.Location + `","RX_QRA":"` + gridSquare + `","RX_ASL":` + fmt.Sprintf("%d", kc.config.Admin.ASL) + `,"RX_GMAP":""},"owner_info":"` + ownerInfo + `","init":{"freq":` + fmt.Sprintf("%.3f", float64(initialFrequency)/1000) + `,"mode":"cw","zoom":0,"max_dB":-10,"min_dB":-110},"waterfall_cal":-3,"waterfall_min_dB":-110,"waterfall_max_dB":-10,"snr_meas_interval_hrs":0}`
 	cfgJSONEncoded := url.QueryEscape(cfgJSON)
 	cfgJSONEncoded = strings.ReplaceAll(cfgJSONEncoded, "+", "%20")
 	kc.sendMsg("load_cfg", cfgJSONEncoded)
@@ -1784,8 +1785,8 @@ func (kc *kiwiConn) sendInitMessages() {
 	kc.sendMsg("load_dxcomm_cfg", dxcommJSONEncoded)
 
 	// Center frequency and bandwidth
-	kc.sendMsg("center_freq", "15000000")
-	kc.sendMsg("bandwidth", "30000000")
+	kc.sendMsg("center_freq", fmt.Sprintf("%d", minFrequency+(maxFrequency-minFrequency)/2))
+	kc.sendMsg("bandwidth", fmt.Sprintf("%d", maxFrequency-minFrequency))
 	kc.sendMsg("adc_clk_nom", "66666600")
 
 	if kc.connType == "SND" {
@@ -1857,10 +1858,10 @@ func (kc *kiwiConn) sendInitMessages() {
 			}
 			kc.session = session
 
-			// Configure initial spectrum parameters (zoom 0 = full 30 MHz span)
-			// Full span = 30 MHz, zoom 0 = 30000 kHz / 1024 bins = 29.296875 kHz/bin
-			initialBinBandwidth := 30000000.0 / 1024.0 // Hz per bin at zoom 0
-			initialFreq := uint64(15000000)            // Center frequency: 15 MHz
+			// Configure initial spectrum parameters for full receiver coverage.
+			minFrequency, maxFrequency := kc.config.SpectrumRange()
+			initialBinBandwidth := float64(maxFrequency-minFrequency) / 1024
+			initialFreq := minFrequency + (maxFrequency-minFrequency)/2
 			updated := kc.sessions.UpdateSpectrumSessionByUserID(kc.userSessionID, initialFreq, initialBinBandwidth)
 			if !updated {
 				log.Printf("Warning: Failed to configure initial spectrum session")

--- a/main.go
+++ b/main.go
@@ -30,12 +30,14 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/cwsl/ka9q_ubersdr/audio_extensions/digitalvoice"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/drm"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/freedv"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/fsk"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/ft8"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/morse"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/navtex"
+	"github.com/cwsl/ka9q_ubersdr/audio_extensions/signalling"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/soundmodem"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/sstv"
 	"github.com/cwsl/ka9q_ubersdr/audio_extensions/wefax"
@@ -1776,6 +1778,84 @@ func main() {
 		log.Printf("Sound Modem extension disabled (soundmodem_extension.enabled: false)")
 	}
 
+	// Register receive-only digital voice decoding through DSD-FME. The
+	// extension itself owns the protocol allowlist and does not accept arbitrary
+	// command-line arguments or privacy/decryption keys from clients.
+	digitalVoiceEnabled := config.DigitalVoice.Enabled == nil || *config.DigitalVoice.Enabled
+	if digitalVoiceEnabled {
+		digitalVoiceMaxUsers := config.DigitalVoice.MaxUsers
+		if digitalVoiceMaxUsers == 0 {
+			digitalVoiceMaxUsers = 3
+		}
+		digitalvoice.GlobalConfig = &digitalvoice.Config{
+			BinaryPath: config.DigitalVoice.BinaryPath,
+			MaxUsers:   digitalVoiceMaxUsers,
+		}
+		digitalVoiceInfo := digitalvoice.GetInfo()
+		digitalVoiceFactoryWrapper := func(audioParams AudioExtensionParams, extensionParams map[string]interface{}) (AudioExtension, error) {
+			dvParams := digitalvoice.AudioExtensionParams{
+				SampleRate:    audioParams.SampleRate,
+				Channels:      audioParams.Channels,
+				BitsPerSample: audioParams.BitsPerSample,
+			}
+			dvExt, err := digitalvoice.Factory(dvParams, extensionParams)
+			if err != nil {
+				return nil, err
+			}
+			return &digitalVoiceExtensionWrapper{ext: dvExt}, nil
+		}
+		audioExtensionRegistry.Register(
+			"digitalvoice",
+			digitalVoiceFactoryWrapper,
+			AudioExtensionInfo{
+				Name:        digitalVoiceInfo["name"].(string),
+				Description: digitalVoiceInfo["description"].(string),
+				Version:     digitalVoiceInfo["version"].(string),
+			},
+		)
+		log.Printf("Registered audio extension: digitalvoice v%s", digitalVoiceInfo["version"].(string))
+	} else {
+		log.Printf("Digital voice extension disabled (digital_voice_extension.enabled: false)")
+	}
+
+	// Register paging and common signalling decoding through multimon-ng.
+	signallingEnabled := config.Signalling.Enabled == nil || *config.Signalling.Enabled
+	if signallingEnabled {
+		signallingMaxUsers := config.Signalling.MaxUsers
+		if signallingMaxUsers == 0 {
+			signallingMaxUsers = 5
+		}
+		signalling.GlobalConfig = &signalling.Config{
+			BinaryPath: config.Signalling.BinaryPath,
+			MaxUsers:   signallingMaxUsers,
+		}
+		signallingInfo := signalling.GetInfo()
+		signallingFactoryWrapper := func(audioParams AudioExtensionParams, extensionParams map[string]interface{}) (AudioExtension, error) {
+			params := signalling.AudioExtensionParams{
+				SampleRate:    audioParams.SampleRate,
+				Channels:      audioParams.Channels,
+				BitsPerSample: audioParams.BitsPerSample,
+			}
+			extension, err := signalling.Factory(params, extensionParams)
+			if err != nil {
+				return nil, err
+			}
+			return &signallingExtensionWrapper{ext: extension}, nil
+		}
+		audioExtensionRegistry.Register(
+			"signalling",
+			signallingFactoryWrapper,
+			AudioExtensionInfo{
+				Name:        signallingInfo["name"].(string),
+				Description: signallingInfo["description"].(string),
+				Version:     signallingInfo["version"].(string),
+			},
+		)
+		log.Printf("Registered audio extension: signalling v%s", signallingInfo["version"].(string))
+	} else {
+		log.Printf("Signalling extension disabled (signalling_extension.enabled: false)")
+	}
+
 	// Register FreeDV extension
 	// Callsign and locator come from the instance config; the frontend only provides freq_hz
 	freedvMaxUsers := config.FreeDVExtension.MaxUsers
@@ -2944,6 +3024,7 @@ func main() {
 	http.HandleFunc("/admin/decoder-config", adminHandler.AuthMiddleware(adminHandler.HandleDecoderConfig))
 	http.HandleFunc("/admin/decoder-bands", adminHandler.AuthMiddleware(adminHandler.HandleDecoderBands))
 	http.HandleFunc("/admin/cwskimmer-config", adminHandler.AuthMiddleware(adminHandler.HandleCWSkimmerConfig))
+	http.HandleFunc("/admin/receiver-profiles", adminHandler.AuthMiddleware(adminHandler.HandleReceiverProfiles))
 	http.HandleFunc("/admin/radiod-config", adminHandler.AuthMiddleware(adminHandler.HandleRadiodConfig))
 	http.HandleFunc("/admin/radiod-values", adminHandler.AuthMiddleware(adminHandler.HandleRadiodValues))
 	http.HandleFunc("/admin/system-stats", adminHandler.AuthMiddleware(adminHandler.HandleSystemStats))
@@ -4142,8 +4223,8 @@ func handleBookmarks(w http.ResponseWriter, r *http.Request, config *Config, eib
 
 	// Optional frequency-span filter: ?center=<Hz>&width=<Hz>
 	// Both parameters must be present and valid for the filter to apply.
-	// Valid range for this system is 0–30 MHz (0–30,000,000 Hz).
-	const maxFreqHz = 30_000_000.0
+	minConfiguredHz, maxConfiguredHz := config.FrequencyRange()
+	minFreqHz, maxFreqHz := float64(minConfiguredHz), float64(maxConfiguredHz)
 	q := r.URL.Query()
 	centerStr := q.Get("center")
 	widthStr := q.Get("width")
@@ -4158,8 +4239,8 @@ func handleBookmarks(w http.ResponseWriter, r *http.Request, config *Config, eib
 			http.Error(w, fmt.Sprintf("invalid width parameter: %v", errW), http.StatusBadRequest)
 			return
 		}
-		if centerHz < 0 || centerHz > maxFreqHz {
-			http.Error(w, fmt.Sprintf("center must be between 0 and %.0f Hz", maxFreqHz), http.StatusBadRequest)
+		if centerHz < minFreqHz || centerHz > maxFreqHz {
+			http.Error(w, fmt.Sprintf("center must be between %.0f and %.0f Hz", minFreqHz, maxFreqHz), http.StatusBadRequest)
 			return
 		}
 		if widthHz < 0 || widthHz > maxFreqHz {
@@ -4168,16 +4249,16 @@ func handleBookmarks(w http.ResponseWriter, r *http.Request, config *Config, eib
 		}
 		loHz := centerHz - widthHz
 		hiHz := centerHz + widthHz
-		// Clamp span to the valid system range.
-		if loHz < 0 {
-			loHz = 0
+		// Clamp span to configured receiver coverage.
+		if loHz < minFreqHz {
+			loHz = minFreqHz
 		}
 		if hiHz > maxFreqHz {
 			hiHz = maxFreqHz
 		}
 		// Reject if the span doesn't overlap the system range at all.
-		if loHz > maxFreqHz || hiHz < 0 {
-			http.Error(w, "center/width span is outside the 0–30 MHz system range", http.StatusBadRequest)
+		if loHz > maxFreqHz || hiHz < minFreqHz {
+			http.Error(w, "center/width span is outside configured receiver coverage", http.StatusBadRequest)
 			return
 		}
 		spanFiltered := filteredBookmarks[:0]
@@ -4522,10 +4603,11 @@ func handleDescription(w http.ResponseWriter, r *http.Request, config *Config, c
 	// Calculate Maidenhead grid locator from GPS coordinates
 	maidenhead := latLonToGridSquare(config.Admin.GPS.Lat, config.Admin.GPS.Lon)
 
-	// Resolve and sanitise default frequency (must be in valid HF range 10 kHz–30 MHz)
+	// Resolve and sanitise default frequency against configured receiver coverage.
 	effectiveDefaultFreq := config.Admin.DefaultFrequency
-	if effectiveDefaultFreq < 10000 || effectiveDefaultFreq > 30000000 {
-		effectiveDefaultFreq = 14175000 // built-in default: 14.175 MHz (20m USB calling)
+	if !config.IsFrequencySupported(effectiveDefaultFreq) {
+		minHz, maxHz := config.FrequencyRange()
+		effectiveDefaultFreq = minHz + (maxHz-minHz)/2
 	}
 
 	// Resolve and sanitise default mode (must be one of the known demodulation modes)
@@ -4555,6 +4637,7 @@ func handleDescription(w http.ResponseWriter, r *http.Request, config *Config, c
 			}
 		}
 	}
+	minSpectrumFrequency, maxSpectrumFrequency := config.SpectrumRange()
 
 	// Build the response with description plus status information (without sdrs)
 	response := map[string]interface{}{
@@ -4562,9 +4645,17 @@ func handleDescription(w http.ResponseWriter, r *http.Request, config *Config, c
 		"default_frequency": effectiveDefaultFreq,
 		"default_mode":      effectiveDefaultMode,
 		"receiver": map[string]interface{}{
-			"name":       config.Admin.Name,
-			"callsign":   config.Admin.Callsign,
-			"public_url": publicURL,
+			"name":             config.Admin.Name,
+			"callsign":         config.Admin.Callsign,
+			"public_url":       publicURL,
+			"backend":          config.Receiver.Backend,
+			"driver":           config.Receiver.Driver,
+			"device":           config.Receiver.Device,
+			"sample_rate":      config.Receiver.SampleRate,
+			"frequency_min_hz": config.Receiver.FrequencyMinHz,
+			"frequency_max_hz": config.Receiver.FrequencyMaxHz,
+			"spectrum_min_hz":  minSpectrumFrequency,
+			"spectrum_max_hz":  maxSpectrumFrequency,
 			"gps": map[string]interface{}{
 				"lat":          config.Admin.GPS.Lat,
 				"lon":          config.Admin.GPS.Lon,
@@ -4719,11 +4810,20 @@ func handleStatus(w http.ResponseWriter, r *http.Request, config *Config) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
+	minFrequency, maxFrequency := config.FrequencyRange()
+	centerFrequency := minFrequency + (maxFrequency-minFrequency)/2
+	profileName := fmt.Sprintf("%d-%d Hz", minFrequency, maxFrequency)
+
 	// Build the status response
 	response := map[string]interface{}{
 		"receiver": map[string]interface{}{
-			"name":  config.Admin.Name,
-			"admin": config.Admin.Email,
+			"name":             config.Admin.Name,
+			"admin":            config.Admin.Email,
+			"backend":          config.Receiver.Backend,
+			"driver":           config.Receiver.Driver,
+			"device":           config.Receiver.Device,
+			"frequency_min_hz": minFrequency,
+			"frequency_max_hz": maxFrequency,
 			"gps": map[string]interface{}{
 				"lat": config.Admin.GPS.Lat,
 				"lon": config.Admin.GPS.Lon,
@@ -4739,9 +4839,9 @@ func handleStatus(w http.ResponseWriter, r *http.Request, config *Config) {
 				"type": "SDR",
 				"profiles": []map[string]interface{}{
 					{
-						"name":        "0-30 MHz",
-						"center_freq": 15000000, // 15 MHz in Hz
-						"sample_rate": 64000000, // 64 MHz in Hz
+						"name":        profileName,
+						"center_freq": centerFrequency,
+						"sample_rate": config.Receiver.SampleRate,
 					},
 				},
 			},
@@ -5478,7 +5578,7 @@ func handleNoiseFloorConfig(w http.ResponseWriter, r *http.Request, config *Conf
 		}
 	}
 
-	// Synthetic "wideband" pseudo-band (0-30 MHz, the same channel used by the
+	// Synthetic receiver-wide pseudo-band (the same channel used by the
 	// spectrogram) — always available whenever noise floor monitoring is
 	// enabled, independent of individual band configuration. Selectable on
 	// the spectrum SSE stream via ?band=wideband.
@@ -5487,14 +5587,16 @@ func handleNoiseFloorConfig(w http.ResponseWriter, r *http.Request, config *Conf
 	// entry there into its per-band UI state (band-selector dropdown, FFT
 	// canvases, historical/aggregate lookups), none of which support a
 	// "wideband" band. It is exposed as a separate top-level field instead.
+	minSpectrumFrequency, maxSpectrumFrequency := config.SpectrumRange()
+	wideBandBinBandwidth := float64(maxSpectrumFrequency-minSpectrumFrequency) / 4096
 	wideband := map[string]interface{}{
 		"name":             wideBandSSEName,
-		"start":            uint64(0),
-		"end":              uint64(30_000_000),
-		"center_frequency": uint64(wideBandSSECenterHz),
+		"start":            minSpectrumFrequency,
+		"end":              maxSpectrumFrequency,
+		"center_frequency": minSpectrumFrequency + (maxSpectrumFrequency-minSpectrumFrequency)/2,
 		"bin_count":        4096,
-		"bin_bandwidth":    7324.21875,
-		"total_bandwidth":  float64(4096) * 7324.21875,
+		"bin_bandwidth":    wideBandBinBandwidth,
+		"total_bandwidth":  float64(maxSpectrumFrequency - minSpectrumFrequency),
 		"ft8_frequency":    uint64(0),
 		"ft8_markers":      ft8Markers,
 	}
@@ -6906,6 +7008,78 @@ func (w *soundmodemExtensionWrapper) SetOutputMode(mode soundmodem.OutputMode) e
 func (w *soundmodemExtensionWrapper) CrashChan() <-chan error {
 	if cr, ok := w.ext.(interface{ CrashChan() <-chan error }); ok {
 		return cr.CrashChan()
+	}
+	return nil
+}
+
+// digitalVoiceExtensionWrapper adapts the digitalvoice package types to the
+// main package's audio extension interface.
+type digitalVoiceExtensionWrapper struct {
+	ext digitalvoice.AudioExtension
+}
+
+func (w *digitalVoiceExtensionWrapper) Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error {
+	dvChan := make(chan digitalvoice.AudioSample, cap(audioChan))
+	go func() {
+		defer close(dvChan)
+		for sample := range audioChan {
+			dvChan <- digitalvoice.AudioSample{
+				PCMData:      sample.PCMData,
+				RTPTimestamp: sample.RTPTimestamp,
+				GPSTimeNs:    sample.GPSTimeNs,
+			}
+		}
+	}()
+	return w.ext.Start(dvChan, resultChan)
+}
+
+func (w *digitalVoiceExtensionWrapper) Stop() error {
+	return w.ext.Stop()
+}
+
+func (w *digitalVoiceExtensionWrapper) GetName() string {
+	return w.ext.GetName()
+}
+
+func (w *digitalVoiceExtensionWrapper) CrashChan() <-chan error {
+	if reporter, ok := w.ext.(interface{ CrashChan() <-chan error }); ok {
+		return reporter.CrashChan()
+	}
+	return nil
+}
+
+// signallingExtensionWrapper adapts the signalling package types to the main
+// package's audio extension interface.
+type signallingExtensionWrapper struct {
+	ext signalling.AudioExtension
+}
+
+func (w *signallingExtensionWrapper) Start(audioChan <-chan AudioSample, resultChan chan<- []byte) error {
+	signallingChan := make(chan signalling.AudioSample, cap(audioChan))
+	go func() {
+		defer close(signallingChan)
+		for sample := range audioChan {
+			signallingChan <- signalling.AudioSample{
+				PCMData:      sample.PCMData,
+				RTPTimestamp: sample.RTPTimestamp,
+				GPSTimeNs:    sample.GPSTimeNs,
+			}
+		}
+	}()
+	return w.ext.Start(signallingChan, resultChan)
+}
+
+func (w *signallingExtensionWrapper) Stop() error {
+	return w.ext.Stop()
+}
+
+func (w *signallingExtensionWrapper) GetName() string {
+	return w.ext.GetName()
+}
+
+func (w *signallingExtensionWrapper) CrashChan() <-chan error {
+	if reporter, ok := w.ext.(interface{ CrashChan() <-chan error }); ok {
+		return reporter.CrashChan()
 	}
 	return nil
 }

--- a/noise_floor.go
+++ b/noise_floor.go
@@ -326,6 +326,18 @@ func NewNoiseFloorMonitor(config *Config, radiod *RadiodController, sessions *Se
 		fftBuffers:         make(map[string]*FFTBuffer),
 	}
 
+	minReceiverFrequency, maxReceiverFrequency := config.SpectrumRange()
+	validBands := config.NoiseFloor.Bands[:0]
+	for _, band := range config.NoiseFloor.Bands {
+		if band.Start < minReceiverFrequency || band.End > maxReceiverFrequency {
+			log.Printf("Skipping noise-floor band %q (%d-%d Hz): outside instantaneous receiver coverage %d-%d Hz",
+				band.Name, band.Start, band.End, minReceiverFrequency, maxReceiverFrequency)
+			continue
+		}
+		validBands = append(validBands, band)
+	}
+	config.NoiseFloor.Bands = validBands
+
 	// Initialize FFT buffers for each band (store up to 1 minute of samples)
 	for _, band := range config.NoiseFloor.Bands {
 		nfm.fftBuffers[band.Name] = NewFFTBuffer(
@@ -337,13 +349,14 @@ func NewNoiseFloorMonitor(config *Config, radiod *RadiodController, sessions *Se
 		)
 	}
 
-	// Initialize wide-band FFT buffer (0-30 MHz full HF coverage)
-	// Uses 4096 bins @ 7.32421875 kHz/bin for exact 0-30 MHz coverage (4096 * 7324.21875 = 30 MHz)
+	// Initialize the receiver-wide instantaneous FFT buffer.
+	minSpectrumFrequency, maxSpectrumFrequency := config.SpectrumRange()
+	wideBandBinWidth := float64(maxSpectrumFrequency-minSpectrumFrequency) / 4096
 	nfm.wideBandFFTBuffer = NewFFTBuffer(
 		"wideband",
-		0,              // 0 Hz start
-		30000000,       // 30 MHz end
-		7324.21875,     // 7324.21875 Hz bin width (30 MHz / 4096 bins = exact coverage)
+		minSpectrumFrequency,
+		maxSpectrumFrequency,
+		wideBandBinWidth,
 		60*time.Second, // Keep 1 minute of samples
 	)
 
@@ -361,8 +374,7 @@ func (nfm *NoiseFloorMonitor) Start() error {
 
 	log.Printf("Creating noise floor spectrum sessions for %d bands + wide-band", len(nfm.config.NoiseFloor.Bands))
 
-	// Create wide-band spectrum session (0-30 MHz full HF coverage)
-	// Uses same parameters as main spectrum display
+	// Create a spectrum session across instantaneous receiver coverage.
 	wideBandSSRC := uint32(rand.Int31())
 	if wideBandSSRC == 0 || wideBandSSRC == 0xffffffff {
 		wideBandSSRC = 1
@@ -381,17 +393,19 @@ func (nfm *NoiseFloorMonitor) Start() error {
 	}
 	nfm.sessions.mu.RUnlock()
 
-	// Create wide-band spectrum channel
-	// Parameters: 15 MHz center, 4096 bins, 7.32421875 kHz/bin for exact 0-30 MHz coverage
+	minSpectrumFrequency, maxSpectrumFrequency := nfm.config.SpectrumRange()
+	wideBandCenter := minSpectrumFrequency + (maxSpectrumFrequency-minSpectrumFrequency)/2
+	wideBandBinWidth := float64(maxSpectrumFrequency-minSpectrumFrequency) / 4096
 	if DebugMode {
-		log.Printf("DEBUG: Creating wide-band spectrum - freq: 15000000 Hz, bins: 4096, bw: 7324.21875 Hz")
+		log.Printf("DEBUG: Creating wide-band spectrum - freq: %d Hz, bins: 4096, bw: %.6f Hz",
+			wideBandCenter, wideBandBinWidth)
 	}
 
 	if err := nfm.radiod.CreateSpectrumChannel(
 		"noisefloor-wideband",
-		15000000,   // 15 MHz center (covers 0-30 MHz)
-		4096,       // 4096 bins (half of 8192 for lower CPU usage)
-		7324.21875, // 7324.21875 Hz per bin (30 MHz / 4096 = exact 0-30 MHz coverage)
+		wideBandCenter,
+		4096,
+		wideBandBinWidth,
 		wideBandSSRC,
 	); err != nil {
 		return fmt.Errorf("failed to create wide-band spectrum channel: %w", err)
@@ -407,9 +421,9 @@ func (nfm *NoiseFloorMonitor) Start() error {
 		SSRC:         wideBandSSRC,
 		IsSpectrum:   true,
 		IsBackground: true,
-		Frequency:    15000000,
+		Frequency:    wideBandCenter,
 		BinCount:     4096,
-		BinBandwidth: 7324.21875,
+		BinBandwidth: wideBandBinWidth,
 		SpectrumChan: wideBandSpectrumChan,
 		CreatedAt:    time.Now(),
 		LastActive:   time.Now(),
@@ -424,18 +438,19 @@ func (nfm *NoiseFloorMonitor) Start() error {
 	nfm.wideBandSpectrum = &BandSpectrum{
 		Band: NoiseFloorBand{
 			Name:            "wideband",
-			Start:           0,
-			End:             30000000,
-			CenterFrequency: 15000000,
+			Start:           minSpectrumFrequency,
+			End:             maxSpectrumFrequency,
+			CenterFrequency: wideBandCenter,
 			BinCount:        4096,
-			BinBandwidth:    7324.21875,
+			BinBandwidth:    wideBandBinWidth,
 		},
 		SSRC:         wideBandSSRC,
 		SessionID:    wideBandSessionID,
 		SpectrumChan: wideBandSpectrumChan,
 	}
 
-	log.Printf("Created wide-band spectrum session (SSRC: 0x%08x, 7.32 kHz resolution, 0-30 MHz, 4096 bins)", wideBandSSRC)
+	log.Printf("Created wide-band spectrum session (SSRC: 0x%08x, %.2f Hz resolution, %d-%d Hz, 4096 bins)",
+		wideBandSSRC, wideBandBinWidth, minSpectrumFrequency, maxSpectrumFrequency)
 
 	// Create a spectrum session for each band
 	for _, band := range nfm.config.NoiseFloor.Bands {
@@ -761,26 +776,14 @@ func (nfm *NoiseFloorMonitor) calculateAndLogStatistics() {
 	timestamp := time.Now()
 	bandsProcessed := 0
 
-	// Calculate wideband SNR measurements (0-30 MHz and 1.8-30 MHz)
+	// Calculate receiver-wide and HF-overlap dynamic range measurements.
 	var snr_0_30, snr_1_8_30 float32
 	if nfm.wideBandFFTBuffer != nil {
 		widebandFFT := nfm.wideBandFFTBuffer.GetAveragedFFT(10 * time.Second)
 		if widebandFFT != nil && len(widebandFFT.Data) > 0 {
-			// Calculate 0-30 MHz SNR (dynamic range = P95 - P5)
-			_, _, fullDynamicRange := calculateDynamicRangeFromFFT(widebandFFT.Data)
-			snr_0_30 = fullDynamicRange
-
-			// Calculate 1.8-30 MHz HF SNR
-			// Wideband FFT covers 0-30 MHz with bin width of 7324.21875 Hz
-			// 1.8 MHz starts at bin: 1800000 / 7324.21875 ≈ 246
-			startBin := int(1800000.0 / widebandFFT.BinWidth)
-			if startBin < len(widebandFFT.Data) {
-				hfBins := widebandFFT.Data[startBin:]
-				_, _, hfDynamicRange := calculateDynamicRangeFromFFT(hfBins)
-				snr_1_8_30 = hfDynamicRange
-			}
-
-			log.Printf("Wideband SNR: 0-30 MHz = %.1f dB, 1.8-30 MHz = %.1f dB", snr_0_30, snr_1_8_30)
+			snr_0_30, snr_1_8_30 = calculateWidebandDynamicRanges(widebandFFT)
+			log.Printf("Wideband dynamic range: %d-%d Hz = %.1f dB, HF overlap = %.1f dB",
+				widebandFFT.StartFreq, widebandFFT.EndFreq, snr_0_30, snr_1_8_30)
 		}
 	}
 
@@ -1516,7 +1519,41 @@ func copyBandFFT(fft *BandFFT) *BandFFT {
 	return &cp
 }
 
-// GetWidebandSNR returns the current wideband SNR measurements (0-30 MHz and 1.8-30 MHz)
+// calculateWidebandDynamicRanges returns the full instantaneous dynamic range
+// and, when present, the portion overlapping 1.8-30 MHz. Field names in public
+// APIs remain legacy-compatible.
+func calculateWidebandDynamicRanges(fft *BandFFT) (overall, hf float32) {
+	if fft == nil || len(fft.Data) == 0 {
+		return 0, 0
+	}
+	_, _, overall = calculateDynamicRangeFromFFT(fft.Data)
+
+	hfStart := uint64(1_800_000)
+	if fft.StartFreq > hfStart {
+		hfStart = fft.StartFreq
+	}
+	hfEnd := uint64(30_000_000)
+	if fft.EndFreq < hfEnd {
+		hfEnd = fft.EndFreq
+	}
+	if hfEnd <= hfStart || fft.BinWidth <= 0 {
+		return overall, 0
+	}
+	startBin := int(float64(hfStart-fft.StartFreq) / fft.BinWidth)
+	endBin := int(math.Ceil(float64(hfEnd-fft.StartFreq) / fft.BinWidth))
+	if startBin < 0 {
+		startBin = 0
+	}
+	if endBin > len(fft.Data) {
+		endBin = len(fft.Data)
+	}
+	if startBin < endBin {
+		_, _, hf = calculateDynamicRangeFromFFT(fft.Data[startBin:endBin])
+	}
+	return overall, hf
+}
+
+// GetWidebandSNR returns receiver-wide and HF-overlap dynamic range values.
 // Returns -1 for both values if no data is available
 func (nfm *NoiseFloorMonitor) GetWidebandSNR() (snr_0_30, snr_1_8_30 float32) {
 	if nfm == nil {
@@ -1529,21 +1566,7 @@ func (nfm *NoiseFloorMonitor) GetWidebandSNR() (snr_0_30, snr_1_8_30 float32) {
 	if nfm.wideBandFFTBuffer != nil {
 		widebandFFT := nfm.wideBandFFTBuffer.GetAveragedFFT(10 * time.Second)
 		if widebandFFT != nil && len(widebandFFT.Data) > 0 {
-			// Calculate 0-30 MHz SNR (dynamic range = P95 - P5)
-			_, _, fullDynamicRange := calculateDynamicRangeFromFFT(widebandFFT.Data)
-			snr_0_30 = fullDynamicRange
-
-			// Calculate 1.8-30 MHz HF SNR
-			// Wideband FFT covers 0-30 MHz with bin width of 7324.21875 Hz
-			// 1.8 MHz starts at bin: 1800000 / 7324.21875 ≈ 246
-			startBin := int(1800000.0 / widebandFFT.BinWidth)
-			if startBin < len(widebandFFT.Data) {
-				hfBins := widebandFFT.Data[startBin:]
-				_, _, hfDynamicRange := calculateDynamicRangeFromFFT(hfBins)
-				snr_1_8_30 = hfDynamicRange
-			}
-
-			return snr_0_30, snr_1_8_30
+			return calculateWidebandDynamicRanges(widebandFFT)
 		}
 	}
 

--- a/noise_floor_spectrum_sse.go
+++ b/noise_floor_spectrum_sse.go
@@ -128,8 +128,9 @@ import (
 // NAT sessions alive and give clients a liveness signal.
 const nfSpectrumSSEHeartbeatInterval = 30 * time.Second
 
-// wideBandSSEName and wideBandSSECenterHz describe the synthetic "wideband"
-// pseudo-band exposed on this endpoint. It mirrors the 0-30 MHz channel used
+// wideBandSSEName identifies the synthetic receiver-wide pseudo-band.
+// Its center is derived from Config.SpectrumRange at request time. It mirrors
+// the channel used
 // by the spectrogram (see NewSpectrogramRecorder / nfm.GetWideBandFFT) and is
 // fetched separately from the per-band fftBuffers map.
 //
@@ -137,10 +138,7 @@ const nfSpectrumSSEHeartbeatInterval = 30 * time.Second
 // memoized against background_poll_period_ms itself (see that function in
 // noise_floor.go), so there's no separate cost-bounding cadence to manage
 // here; asking for it every tick, same as any other band, is already cheap.
-const (
-	wideBandSSEName     = "wideband"
-	wideBandSSECenterHz = 15_000_000
-)
+const wideBandSSEName = "wideband"
 
 // encodeBinary8PacketForSSE encodes []float32 spectrum data into the SPEC binary8
 // wire format used by both the WebSocket spectrum path and this SSE endpoint.
@@ -335,7 +333,7 @@ func HandleNoiseFloorSpectrumStream(
 		}
 
 		// ── build the set of configured bands (name → center frequency) ───────
-		// Includes a synthetic "wideband" entry (0-30 MHz, center 15 MHz) backed
+		// Includes a synthetic "wideband" entry backed
 		// by nfm.GetWideBandFFT() rather than the per-band fftBuffers map — see
 		// the fetch in the main event loop below. It is only streamed when
 		// explicitly requested via ?band=wideband, not included in the default
@@ -344,7 +342,8 @@ func HandleNoiseFloorSpectrumStream(
 		for _, b := range config.NoiseFloor.Bands {
 			configuredBands[b.Name] = b.CenterFrequency
 		}
-		configuredBands[wideBandSSEName] = wideBandSSECenterHz
+		minSpectrumFrequency, maxSpectrumFrequency := config.SpectrumRange()
+		configuredBands[wideBandSSEName] = minSpectrumFrequency + (maxSpectrumFrequency-minSpectrumFrequency)/2
 
 		// ── parse ?band= query parameters ────────────────────────────────────
 		// Repeatable: ?band=20m&band=40m

--- a/sdr_backend.go
+++ b/sdr_backend.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
+
+// SDRCapabilities declares the limits that planning, validation, and the UI
+// need before opening a receiver. Values are in Hz; a zero maximum means the
+// backend cannot state a reliable limit.
+type SDRCapabilities struct {
+	MinFrequencyHz uint64
+	MaxFrequencyHz uint64
+	MaxSampleRate  uint64
+	Channels       int
+	SupportsIQ     bool
+	SupportsGPSDO  bool
+	SupportsGain   bool
+}
+
+// SDRBackend is a hardware or receiver-service adapter. It intentionally
+// describes capability and configuration validation separately from UberSDR's
+// session/channel API; direct-IQ backends can be added without making USB or
+// network details leak into SessionManager.
+type SDRBackend interface {
+	ID() string
+	DisplayName() string
+	Capabilities() SDRCapabilities
+	ValidateConfig(map[string]any) error
+}
+
+type SDRBackendRegistry struct {
+	mu       sync.RWMutex
+	backends map[string]SDRBackend
+}
+
+func NewSDRBackendRegistry() *SDRBackendRegistry {
+	return &SDRBackendRegistry{backends: make(map[string]SDRBackend)}
+}
+
+func (r *SDRBackendRegistry) Register(backend SDRBackend) error {
+	if backend == nil || backend.ID() == "" {
+		return fmt.Errorf("SDR backend must have an ID")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.backends[backend.ID()]; exists {
+		return fmt.Errorf("SDR backend %q is already registered", backend.ID())
+	}
+	r.backends[backend.ID()] = backend
+	return nil
+}
+
+func (r *SDRBackendRegistry) Lookup(id string) (SDRBackend, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	backend, ok := r.backends[id]
+	return backend, ok
+}
+
+func (r *SDRBackendRegistry) IDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.backends))
+	for id := range r.backends {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// radiodBackend is the initial adapter. It represents the existing KA9Q
+// receiver service, preserving its multicast control/data model while giving
+// new source adapters a stable catalog entry point.
+type radiodBackend struct{}
+
+func (radiodBackend) ID() string          { return "ka9q-radiod" }
+func (radiodBackend) DisplayName() string { return "KA9Q radiod receiver service" }
+func (radiodBackend) Capabilities() SDRCapabilities {
+	return SDRCapabilities{Channels: 1, SupportsIQ: true, SupportsGain: true}
+}
+func (radiodBackend) ValidateConfig(config map[string]any) error {
+	if config == nil {
+		return fmt.Errorf("ka9q-radiod requires status_group, data_group, and interface configuration")
+	}
+	for _, key := range []string{"status_group", "data_group", "interface"} {
+		if value, ok := config[key].(string); !ok || value == "" {
+			return fmt.Errorf("ka9q-radiod requires %s", key)
+		}
+	}
+	return nil
+}
+
+var defaultSDRBackends = newBuiltinSDRBackendRegistry()
+
+func newBuiltinSDRBackendRegistry() *SDRBackendRegistry {
+	registry := NewSDRBackendRegistry()
+	if err := registry.Register(radiodBackend{}); err != nil {
+		panic(err)
+	}
+	return registry
+}

--- a/sdr_backend.go
+++ b/sdr_backend.go
@@ -1,22 +1,139 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"net"
+	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 )
+
+const (
+	defaultReceiverMinHz = uint64(10_000)
+	defaultReceiverMaxHz = uint64(30_000_000)
+)
+
+// ReceiverConfig describes the receiver service used by UberSDR and the RF
+// coverage that it makes available. KA9Q radiod remains the channel engine;
+// the backend/driver metadata lets the rest of UberSDR stop assuming RX888/HF.
+type ReceiverConfig struct {
+	Backend         string            `yaml:"backend" json:"backend"`
+	Driver          string            `yaml:"driver" json:"driver"`
+	Device          string            `yaml:"device,omitempty" json:"device,omitempty"`
+	Description     string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Serial          string            `yaml:"serial,omitempty" json:"serial,omitempty"`
+	SampleRate      uint64            `yaml:"sample_rate,omitempty" json:"sample_rate,omitempty"`
+	CenterFrequency uint64            `yaml:"center_frequency,omitempty" json:"center_frequency,omitempty"`
+	FrequencyMinHz  uint64            `yaml:"frequency_min_hz" json:"frequency_min_hz"`
+	FrequencyMaxHz  uint64            `yaml:"frequency_max_hz" json:"frequency_max_hz"`
+	Options         map[string]string `yaml:"options,omitempty" json:"options,omitempty"`
+}
+
+func (c *ReceiverConfig) applyDefaults() {
+	if c.Backend == "" {
+		c.Backend = "ka9q-radiod"
+	}
+	if c.Driver == "" && c.Backend == "ka9q-radiod" {
+		c.Driver = "rx888"
+	}
+	if c.Device == "" && c.Backend == "ka9q-radiod" {
+		c.Device = c.Driver
+	}
+	if c.FrequencyMinHz == 0 {
+		c.FrequencyMinHz = defaultReceiverMinHz
+	}
+	if c.FrequencyMaxHz == 0 {
+		c.FrequencyMaxHz = defaultReceiverMaxHz
+	}
+}
+
+func (c ReceiverConfig) Validate() error {
+	c.applyDefaults()
+	if _, ok := defaultSDRBackends.Lookup(c.Backend); !ok {
+		return fmt.Errorf("receiver.backend %q is not registered (available: %s)",
+			c.Backend, strings.Join(defaultSDRBackends.IDs(), ", "))
+	}
+	if c.FrequencyMaxHz <= c.FrequencyMinHz {
+		return fmt.Errorf("receiver.frequency_max_hz must be greater than receiver.frequency_min_hz")
+	}
+	if c.CenterFrequency != 0 &&
+		(c.CenterFrequency < c.FrequencyMinHz || c.CenterFrequency > c.FrequencyMaxHz) {
+		return fmt.Errorf("receiver.center_frequency must be inside configured receiver coverage")
+	}
+	if c.Backend == "ka9q-radiod" {
+		if _, ok := defaultSDRDeviceProfiles.Lookup(c.Driver); !ok {
+			return fmt.Errorf("receiver.driver %q is not a supported KA9Q Radio driver (available: %s)",
+				c.Driver, strings.Join(defaultSDRDeviceProfiles.IDs(), ", "))
+		}
+	}
+	return validateReceiverOptions(c.Options)
+}
+
+// FrequencyRange returns the configured RF coverage. LoadConfig applies legacy
+// defaults, but this fallback also keeps directly-constructed Config values safe.
+func (c *Config) FrequencyRange() (uint64, uint64) {
+	minHz, maxHz := c.Receiver.FrequencyMinHz, c.Receiver.FrequencyMaxHz
+	if minHz == 0 {
+		minHz = defaultReceiverMinHz
+	}
+	if maxHz <= minHz {
+		minHz, maxHz = defaultReceiverMinHz, defaultReceiverMaxHz
+	}
+	return minHz, maxHz
+}
+
+// SpectrumRange returns the largest contiguous range that can be sampled at
+// once. Tunable coverage can be much wider than instantaneous sample rate for
+// devices such as RTL-SDR, Airspy, and HackRF.
+func (c *Config) SpectrumRange() (uint64, uint64) {
+	minHz, maxHz := c.FrequencyRange()
+	coverageSpan := maxHz - minHz
+	if c.Receiver.SampleRate == 0 || c.Receiver.SampleRate >= coverageSpan {
+		return minHz, maxHz
+	}
+
+	span := c.Receiver.SampleRate
+	center := c.Receiver.CenterFrequency
+	if center < minHz || center > maxHz {
+		center = minHz + coverageSpan/2
+	}
+	start := minHz
+	if center > span/2 {
+		start = center - span/2
+	}
+	if start < minHz {
+		start = minHz
+	}
+	if start > maxHz-span {
+		start = maxHz - span
+	}
+	return start, start + span
+}
+
+func (c *Config) IsFrequencySupported(frequency uint64) bool {
+	minHz, maxHz := c.FrequencyRange()
+	return frequency >= minHz && frequency <= maxHz
+}
+
+func (c *Config) FrequencyRangeLabel() string {
+	minHz, maxHz := c.FrequencyRange()
+	return fmt.Sprintf("%d-%d Hz", minHz, maxHz)
+}
 
 // SDRCapabilities declares the limits that planning, validation, and the UI
 // need before opening a receiver. Values are in Hz; a zero maximum means the
 // backend cannot state a reliable limit.
 type SDRCapabilities struct {
-	MinFrequencyHz uint64
-	MaxFrequencyHz uint64
-	MaxSampleRate  uint64
-	Channels       int
-	SupportsIQ     bool
-	SupportsGPSDO  bool
-	SupportsGain   bool
+	MinFrequencyHz uint64 `json:"min_frequency_hz"`
+	MaxFrequencyHz uint64 `json:"max_frequency_hz"`
+	MaxSampleRate  uint64 `json:"max_sample_rate"`
+	Channels       int    `json:"channels"`
+	SupportsIQ     bool   `json:"supports_iq"`
+	SupportsGPSDO  bool   `json:"supports_gpsdo"`
+	SupportsGain   bool   `json:"supports_gain"`
 }
 
 // SDRBackend is a hardware or receiver-service adapter. It intentionally
@@ -82,9 +199,9 @@ func (radiodBackend) Capabilities() SDRCapabilities {
 }
 func (radiodBackend) ValidateConfig(config map[string]any) error {
 	if config == nil {
-		return fmt.Errorf("ka9q-radiod requires status_group, data_group, and interface configuration")
+		return fmt.Errorf("ka9q-radiod requires status_group and data_group configuration")
 	}
-	for _, key := range []string{"status_group", "data_group", "interface"} {
+	for _, key := range []string{"status_group", "data_group"} {
 		if value, ok := config[key].(string); !ok || value == "" {
 			return fmt.Errorf("ka9q-radiod requires %s", key)
 		}
@@ -92,12 +209,194 @@ func (radiodBackend) ValidateConfig(config map[string]any) error {
 	return nil
 }
 
+// externalRadiodBackend accepts any hardware or bridge that exposes the KA9Q
+// multicast control/status/data protocol. This is the escape hatch for SoapySDR
+// sidecars, remote receivers, and vendor devices not compiled into local radiod.
+type externalRadiodBackend struct{}
+
+func (externalRadiodBackend) ID() string          { return "external-radiod" }
+func (externalRadiodBackend) DisplayName() string { return "External KA9Q-compatible receiver service" }
+func (externalRadiodBackend) Capabilities() SDRCapabilities {
+	return SDRCapabilities{Channels: 1, SupportsIQ: true}
+}
+func (externalRadiodBackend) ValidateConfig(config map[string]any) error {
+	return radiodBackend{}.ValidateConfig(config)
+}
+
 var defaultSDRBackends = newBuiltinSDRBackendRegistry()
 
 func newBuiltinSDRBackendRegistry() *SDRBackendRegistry {
 	registry := NewSDRBackendRegistry()
-	if err := registry.Register(radiodBackend{}); err != nil {
-		panic(err)
+	for _, backend := range []SDRBackend{radiodBackend{}, externalRadiodBackend{}} {
+		if err := registry.Register(backend); err != nil {
+			panic(err)
+		}
 	}
 	return registry
+}
+
+// SDRDeviceProfile describes a receive driver that current KA9Q Radio builds
+// can load. Frequency limits remain deployment configuration because device
+// revisions, converter offsets, front-end filters, and antenna systems differ.
+type SDRDeviceProfile struct {
+	Driver            string   `json:"driver"`
+	DisplayName       string   `json:"display_name"`
+	Family            string   `json:"family"`
+	Native            bool     `json:"native"`
+	ReceiveOnly       bool     `json:"receive_only"`
+	ConfigurationKeys []string `json:"configuration_keys"`
+	Notes             string   `json:"notes,omitempty"`
+}
+
+type SDRDeviceProfileRegistry struct {
+	mu       sync.RWMutex
+	profiles map[string]SDRDeviceProfile
+}
+
+func NewSDRDeviceProfileRegistry() *SDRDeviceProfileRegistry {
+	return &SDRDeviceProfileRegistry{profiles: make(map[string]SDRDeviceProfile)}
+}
+
+func (r *SDRDeviceProfileRegistry) Register(profile SDRDeviceProfile) error {
+	if profile.Driver == "" {
+		return fmt.Errorf("SDR device profile must have a driver")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.profiles[profile.Driver]; exists {
+		return fmt.Errorf("SDR device profile %q is already registered", profile.Driver)
+	}
+	r.profiles[profile.Driver] = profile
+	return nil
+}
+
+func (r *SDRDeviceProfileRegistry) Lookup(driver string) (SDRDeviceProfile, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	profile, ok := r.profiles[driver]
+	return profile, ok
+}
+
+func (r *SDRDeviceProfileRegistry) IDs() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]string, 0, len(r.profiles))
+	for id := range r.profiles {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (r *SDRDeviceProfileRegistry) Profiles() []SDRDeviceProfile {
+	ids := r.IDs()
+	profiles := make([]SDRDeviceProfile, 0, len(ids))
+	for _, id := range ids {
+		profile, _ := r.Lookup(id)
+		profiles = append(profiles, profile)
+	}
+	return profiles
+}
+
+var defaultSDRDeviceProfiles = newBuiltinSDRDeviceProfileRegistry()
+
+func newBuiltinSDRDeviceProfileRegistry() *SDRDeviceProfileRegistry {
+	registry := NewSDRDeviceProfileRegistry()
+	profiles := []SDRDeviceProfile{
+		{Driver: "airspy", DisplayName: "Airspy R2 / Mini", Family: "Airspy", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "converter", "calibrate", "linearity", "lna-agc", "mixer-agc", "lna-gain", "mixer-gain", "vga-gain", "gainstep", "bias", "agc-high-threshold", "agc-low-threshold"}},
+		{Driver: "airspyhf", DisplayName: "Airspy HF+ family", Family: "Airspy", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "hf-agc", "agc-thresh", "hf-att", "hf-lna", "lib-dsp", "calibrate"}},
+		{Driver: "bladerf", DisplayName: "Nuand bladeRF family", Family: "bladeRF", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "frequency", "bandwidth", "gain", "bias", "calibrate"}},
+		{Driver: "fobos", DisplayName: "RigExpert Fobos SDR", Family: "Fobos", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "lna_gain", "vga_gain", "direct_sampling", "clk_source", "ext_clock"}},
+		{Driver: "funcube", DisplayName: "FUNcube Dongle Pro+", Family: "FUNcube", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"number", "frequency", "agc", "bias", "calibrate"}},
+		{Driver: "hackrf", DisplayName: "HackRF family", Family: "HackRF", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "index", "frequency", "lna-gain", "mixer-gain", "if-gain"}},
+		{Driver: "hydrasdr", DisplayName: "HydraSDR family", Family: "HydraSDR", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "converter", "calibrate", "linearity", "lna-agc", "rf-agc", "mixer-agc", "filter-agc", "lna-gain", "rf-gain", "mixer-gain", "filter-gain", "vga-gain", "gainstep", "bias", "agc-high-threshold", "agc-low-threshold"}},
+		{Driver: "rtlsdr", DisplayName: "RTL-SDR compatible dongles", Family: "RTL-SDR", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "gain", "agc", "bias", "direct_sampling", "calibrate"}},
+		{Driver: "rx888", DisplayName: "RX-888 MkII and compatible", Family: "RX-888", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "gainmode", "gain", "att", "atten", "featten", "rfatten", "rfgain", "rxgain", "fegain", "gaincal", "firmware", "dither", "rand", "reference", "undersample", "queuedepth", "reqsize", "reset"}},
+		{Driver: "sdrplay", DisplayName: "SDRplay RSP family", Family: "SDRplay", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "serial", "frequency", "rspduo-mode", "antenna", "ifreq", "bandwidth", "calibrate", "lna-state", "rf-att", "rf-gr", "if-att", "if-gr", "if-agc", "if-agc-rate", "if-agc-setpoint-dbfs", "dc-offset-corr", "iq-imbalance-corr", "bulk-transfer-mode", "rf-notch", "dab-notch", "am-notch", "bias-t"}},
+		{Driver: "sig_gen", DisplayName: "Synthetic signal generator", Family: "Test", Native: true, ReceiveOnly: true, ConfigurationKeys: []string{"samprate", "frequency", "signal-frequency", "signal-amplitude", "noise-amplitude"}},
+	}
+	for _, profile := range profiles {
+		if err := registry.Register(profile); err != nil {
+			panic(err)
+		}
+	}
+	return registry
+}
+
+var radiodOptionNamePattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9_-]*$`)
+
+func validateReceiverOptions(options map[string]string) error {
+	for key, value := range options {
+		if !radiodOptionNamePattern.MatchString(key) {
+			return fmt.Errorf("receiver.options key %q contains unsupported characters", key)
+		}
+		if strings.ContainsAny(value, "\r\n") {
+			return fmt.Errorf("receiver.options.%s must be a single line", key)
+		}
+	}
+	return nil
+}
+
+// BuildRadiodConfig renders a minimal dynamic-channel KA9Q Radio configuration
+// for every native driver profile. Driver-specific settings pass through the
+// validated options map so new upstream knobs do not require an UberSDR release.
+func BuildRadiodConfig(receiver ReceiverConfig, radiod RadiodConfig) (string, error) {
+	receiver.applyDefaults()
+	if receiver.Backend != "ka9q-radiod" {
+		return "", fmt.Errorf("radiod config generation is only available for receiver.backend ka9q-radiod")
+	}
+	if err := receiver.Validate(); err != nil {
+		return "", err
+	}
+	if radiod.StatusGroup == "" || radiod.DataGroup == "" {
+		return "", fmt.Errorf("radiod.status_group and radiod.data_group are required")
+	}
+
+	var output bytes.Buffer
+	fmt.Fprintln(&output, "# Generated by UberSDR. Driver-specific options are preserved from receiver.options.")
+	fmt.Fprintln(&output, "[global]")
+	fmt.Fprintf(&output, "hardware = %s\n", receiver.Driver)
+	fmt.Fprintf(&output, "status = %s\n", radiodGroupHost(radiod.StatusGroup))
+	fmt.Fprintf(&output, "data = %s\n", radiodGroupHost(radiod.DataGroup))
+	fmt.Fprintln(&output, "ttl = 1")
+	fmt.Fprintln(&output, "mode = usb")
+	fmt.Fprintln(&output, "samprate = 12000")
+	fmt.Fprintln(&output, "blocktime = 20")
+	fmt.Fprintln(&output, "overlap = 5")
+	fmt.Fprintln(&output)
+	fmt.Fprintf(&output, "[%s]\n", receiver.Driver)
+	fmt.Fprintf(&output, "device = %s\n", quoteRadiodValue(receiver.Device, receiver.Driver))
+	fmt.Fprintf(&output, "description = %s\n", quoteRadiodValue(receiver.Description, receiver.Driver+" receiver"))
+	if receiver.Serial != "" {
+		fmt.Fprintf(&output, "serial = %s\n", quoteRadiodValue(receiver.Serial, ""))
+	}
+	if receiver.SampleRate > 0 {
+		fmt.Fprintf(&output, "samprate = %d\n", receiver.SampleRate)
+	}
+	if receiver.CenterFrequency > 0 {
+		fmt.Fprintf(&output, "frequency = %d\n", receiver.CenterFrequency)
+	}
+	keys := make([]string, 0, len(receiver.Options))
+	for key := range receiver.Options {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		fmt.Fprintf(&output, "%s = %s\n", key, receiver.Options[key])
+	}
+	return output.String(), nil
+}
+
+func quoteRadiodValue(value, fallback string) string {
+	if value == "" {
+		value = fallback
+	}
+	return strconv.Quote(value)
+}
+
+func radiodGroupHost(group string) string {
+	if host, _, err := net.SplitHostPort(group); err == nil {
+		return host
+	}
+	return group
 }

--- a/sdr_backend_test.go
+++ b/sdr_backend_test.go
@@ -1,0 +1,20 @@
+package main
+
+import "testing"
+
+func TestBuiltInRadiodBackendConfiguration(t *testing.T) {
+	backend, ok := defaultSDRBackends.Lookup("ka9q-radiod")
+	if !ok {
+		t.Fatal("ka9q-radiod backend is not registered")
+	}
+	if err := backend.ValidateConfig(map[string]any{
+		"status_group": "hf-status.local",
+		"data_group":   "pcm.local",
+		"interface":    "eth0",
+	}); err != nil {
+		t.Fatalf("valid radiod configuration rejected: %v", err)
+	}
+	if err := backend.ValidateConfig(map[string]any{"status_group": "hf-status.local"}); err == nil {
+		t.Fatal("incomplete radiod configuration was accepted")
+	}
+}

--- a/sdr_backend_test.go
+++ b/sdr_backend_test.go
@@ -1,6 +1,9 @@
 package main
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestBuiltInRadiodBackendConfiguration(t *testing.T) {
 	backend, ok := defaultSDRBackends.Lookup("ka9q-radiod")
@@ -16,5 +19,109 @@ func TestBuiltInRadiodBackendConfiguration(t *testing.T) {
 	}
 	if err := backend.ValidateConfig(map[string]any{"status_group": "hf-status.local"}); err == nil {
 		t.Fatal("incomplete radiod configuration was accepted")
+	}
+}
+
+func TestBuiltInReceiverCatalog(t *testing.T) {
+	required := []string{
+		"airspy", "airspyhf", "bladerf", "fobos", "funcube", "hackrf",
+		"hydrasdr", "rtlsdr", "rx888", "sdrplay",
+	}
+	for _, driver := range required {
+		if _, ok := defaultSDRDeviceProfiles.Lookup(driver); !ok {
+			t.Errorf("expected built-in receiver profile %q", driver)
+		}
+	}
+	if _, ok := defaultSDRBackends.Lookup("external-radiod"); !ok {
+		t.Error("external radiod adapter is not registered")
+	}
+}
+
+func TestReceiverConfigValidation(t *testing.T) {
+	receiver := ReceiverConfig{
+		Backend:        "ka9q-radiod",
+		Driver:         "rtlsdr",
+		FrequencyMinHz: 24_000_000,
+		FrequencyMaxHz: 1_766_000_000,
+		Options:        map[string]string{"agc": "true"},
+	}
+	if err := receiver.Validate(); err != nil {
+		t.Fatalf("valid receiver rejected: %v", err)
+	}
+
+	receiver.Driver = "not-a-driver"
+	if err := receiver.Validate(); err == nil {
+		t.Fatal("unknown native driver was accepted")
+	}
+
+	receiver.Backend = "external-radiod"
+	if err := receiver.Validate(); err != nil {
+		t.Fatalf("external radiod should accept bridge-specific drivers: %v", err)
+	}
+
+	receiver.Options = map[string]string{"bad\nkey": "value"}
+	if err := receiver.Validate(); err == nil {
+		t.Fatal("unsafe radiod option name was accepted")
+	}
+}
+
+func TestSpectrumRangeUsesInstantaneousSampleRate(t *testing.T) {
+	config := Config{Receiver: ReceiverConfig{
+		FrequencyMinHz:  24_000_000,
+		FrequencyMaxHz:  1_766_000_000,
+		SampleRate:      2_400_000,
+		CenterFrequency: 145_000_000,
+	}}
+	minHz, maxHz := config.SpectrumRange()
+	if minHz != 143_800_000 || maxHz != 146_200_000 {
+		t.Fatalf("unexpected instantaneous spectrum range: %d-%d", minHz, maxHz)
+	}
+
+	config.Receiver.CenterFrequency = 24_000_000
+	minHz, maxHz = config.SpectrumRange()
+	if minHz != 24_000_000 || maxHz != 26_400_000 {
+		t.Fatalf("spectrum range was not clamped to receiver edge: %d-%d", minHz, maxHz)
+	}
+}
+
+func TestBuildRadiodConfig(t *testing.T) {
+	receiver := ReceiverConfig{
+		Backend:         "ka9q-radiod",
+		Driver:          "hackrf",
+		Device:          "hackrf",
+		Description:     "Wideband receiver",
+		Serial:          "00000001",
+		SampleRate:      20_000_000,
+		CenterFrequency: 145_000_000,
+		FrequencyMinHz:  1_000_000,
+		FrequencyMaxHz:  6_000_000_000,
+		Options: map[string]string{
+			"vga-gain": "20",
+			"lna-gain": "16",
+		},
+	}
+	got, err := BuildRadiodConfig(receiver, RadiodConfig{
+		StatusGroup: "239.1.2.3:5006",
+		DataGroup:   "239.1.2.4:5004",
+	})
+	if err != nil {
+		t.Fatalf("BuildRadiodConfig failed: %v", err)
+	}
+	for _, want := range []string{
+		"hardware = hackrf",
+		"status = 239.1.2.3",
+		"data = 239.1.2.4",
+		"[hackrf]",
+		"samprate = 20000000",
+		"frequency = 145000000",
+		"lna-gain = 16",
+		"vga-gain = 20",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("generated config does not contain %q:\n%s", want, got)
+		}
+	}
+	if strings.Index(got, "lna-gain") > strings.Index(got, "vga-gain") {
+		t.Error("driver options are not emitted deterministically")
 	}
 }

--- a/session.go
+++ b/session.go
@@ -862,14 +862,13 @@ func (sm *SessionManager) createSpectrumSessionWithUserIDAndPassword(sourceIP, c
 	binCount := sm.config.Spectrum.Default.BinCount
 	binBandwidth := sm.config.Spectrum.Default.BinBandwidth
 
-	// Validate frequency - must be within HF range (10 kHz – 30 MHz)
-	// If config has invalid frequency, use 15 MHz as fallback (covers 0-30 MHz HF range)
-	const minFrequency = 10000    // 10 kHz minimum
-	const maxFrequency = 30000000 // 30 MHz maximum
-	if frequency < minFrequency || frequency > maxFrequency {
-		log.Printf("WARNING: Invalid spectrum center frequency %d Hz in config (must be %d–%d Hz), using fallback 15 MHz",
-			frequency, minFrequency, maxFrequency)
-		frequency = 15000000 // 15 MHz fallback
+	// Validate against the RF range exposed by the configured receiver.
+	minFrequency, maxFrequency := sm.config.FrequencyRange()
+	if !sm.config.IsFrequencySupported(frequency) {
+		fallback := minFrequency + (maxFrequency-minFrequency)/2
+		log.Printf("WARNING: Invalid spectrum center frequency %d Hz in config (must be %d–%d Hz), using midpoint %d Hz",
+			frequency, minFrequency, maxFrequency, fallback)
+		frequency = fallback
 	}
 
 	// Create spectrum session
@@ -1049,10 +1048,9 @@ func (sm *SessionManager) UpdateSpectrumSession(sessionID string, frequency uint
 		return fmt.Errorf("session %s is not a spectrum session", sessionID)
 	}
 
-	// Validate frequency if provided - must be within HF range (10 kHz – 30 MHz)
-	const minFrequency = 10000    // 10 kHz minimum
-	const maxFrequency = 30000000 // 30 MHz maximum
-	if frequency > 0 && (frequency < minFrequency || frequency > maxFrequency) {
+	// Validate frequency if provided against configured receiver coverage.
+	minFrequency, maxFrequency := sm.config.FrequencyRange()
+	if frequency > 0 && !sm.config.IsFrequencySupported(frequency) {
 		return fmt.Errorf("invalid spectrum frequency %d Hz (must be %d–%d Hz)", frequency, minFrequency, maxFrequency)
 	}
 
@@ -1287,10 +1285,10 @@ func (sm *SessionManager) UpdateSession(sessionID string, frequency uint64, mode
 		return fmt.Errorf("cannot update spectrum session with UpdateSession, use UpdateSpectrumSession instead")
 	}
 
-	// Validate frequency if provided - must not be below minimum
-	const minFrequency = 10000 // 10 kHz minimum
-	if frequency > 0 && frequency < minFrequency {
-		return fmt.Errorf("invalid audio frequency %d Hz (must be >= %d Hz)", frequency, minFrequency)
+	// Validate frequency if provided against configured receiver coverage.
+	minFrequency, maxFrequency := sm.config.FrequencyRange()
+	if frequency > 0 && !sm.config.IsFrequencySupported(frequency) {
+		return fmt.Errorf("invalid audio frequency %d Hz (must be %d–%d Hz)", frequency, minFrequency, maxFrequency)
 	}
 
 	// Update session state only for parameters that changed
@@ -1408,10 +1406,10 @@ func (sm *SessionManager) UpdateSessionWithEdges(sessionID string, frequency uin
 		return fmt.Errorf("cannot update spectrum session with UpdateSessionWithEdges, use UpdateSpectrumSession instead")
 	}
 
-	// Validate frequency if provided - must not be below minimum
-	const minFrequency = 10000 // 10 kHz minimum
-	if frequency > 0 && frequency < minFrequency {
-		return fmt.Errorf("invalid audio frequency %d Hz (must be >= %d Hz)", frequency, minFrequency)
+	// Validate frequency if provided against configured receiver coverage.
+	minFrequency, maxFrequency := sm.config.FrequencyRange()
+	if frequency > 0 && !sm.config.IsFrequencySupported(frequency) {
+		return fmt.Errorf("invalid audio frequency %d Hz (must be %d–%d Hz)", frequency, minFrequency, maxFrequency)
 	}
 
 	// Update session state only for parameters that changed

--- a/spectrogram_recorder.go
+++ b/spectrogram_recorder.go
@@ -72,13 +72,14 @@ type SpectrogramRecorder struct {
 	wg       sync.WaitGroup
 }
 
-// NewSpectrogramRecorder creates a new wideband (0-30 MHz) recorder.
+// NewSpectrogramRecorder creates a recorder for instantaneous receiver coverage.
 // Returns nil if disabled or nfm is nil.
 func NewSpectrogramRecorder(nfm *NoiseFloorMonitor, config SpectrogramConfig) *SpectrogramRecorder {
 	if !config.IsEnabled() || nfm == nil {
 		return nil
 	}
-	return newSpectrogramRecorderForBand(nfm, config, "wideband", 0, 30_000_000, spectrogramBins,
+	startFrequency, endFrequency := nfm.config.SpectrumRange()
+	return newSpectrogramRecorderForBand(nfm, config, "wideband", startFrequency, endFrequency, spectrogramBins,
 		func() *BandFFT { return nfm.GetWideBandFFT() })
 }
 

--- a/static/admin.html
+++ b/static/admin.html
@@ -6629,6 +6629,18 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
             document.getElementById('kiwiBookmarksFileInput').click();
         }
 
+        function adminReceiverMinHz() {
+            return Number(currentConfig?.receiver?.frequency_min_hz) || 10000;
+        }
+
+        function adminReceiverMaxHz() {
+            return Number(currentConfig?.receiver?.frequency_max_hz) || 30000000;
+        }
+
+        function adminReceiverRangeLabel() {
+            return `${adminReceiverMinHz()}–${adminReceiverMaxHz()} Hz`;
+        }
+
         function convertKiwiSDRBookmarks(kiwiBookmarks) {
             // KiwiSDR type code to group name mapping
             const typeToGroup = {
@@ -6659,8 +6671,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                 // Convert frequency from kHz to Hz
                 const frequency = Math.round(freqKHz * 1000);
 
-                // Skip entries outside the valid HF range (10 kHz – 30 MHz)
-                if (frequency < 10000 || frequency > 30000000) {
+                if (frequency < adminReceiverMinHz() || frequency > adminReceiverMaxHz()) {
                     skipped++;
                     continue;
                 }
@@ -6861,12 +6872,12 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                     return;
                 }
 
-                // Convert KiwiSDR bookmarks to UberSDR format (entries > 30 MHz are filtered out)
+                // Convert KiwiSDR bookmarks to UberSDR format.
                 const { bookmarks: importedBookmarks, skipped: skippedFreq } = convertKiwiSDRBookmarks(data.dx);
 
                 if (importedBookmarks.length === 0) {
                     const msg = skippedFreq > 0
-                        ? `No valid bookmarks found in KiwiSDR file (${skippedFreq} skipped: outside 10 kHz – 30 MHz range)`
+                        ? `No valid bookmarks found in KiwiSDR file (${skippedFreq} skipped: outside ${adminReceiverRangeLabel()})`
                         : 'No valid bookmarks found in KiwiSDR file';
                     showAlert(msg, 'error');
                     return;
@@ -6903,7 +6914,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                 await loadBookmarks();
                 let successMsg = `Successfully imported ${importedBookmarks.length} KiwiSDR bookmark(s) (${importMode})`;
                 const totalSkipped = skippedFreq + serverSkipped;
-                if (totalSkipped > 0) successMsg += ` — ${totalSkipped} skipped (outside 10 kHz – 30 MHz)`;
+                if (totalSkipped > 0) successMsg += ` — ${totalSkipped} skipped (outside ${adminReceiverRangeLabel()})`;
                 showAlert(successMsg, 'success');
             } catch (error) {
                 showAlert('Error importing KiwiSDR bookmarks: ' + error.message, 'error');
@@ -6930,7 +6941,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                     const raw = Array.isArray(data) ? data : (data.bookmarks || []);
                     importedBookmarks = raw.filter(b => {
                         const f = Number(b.frequency);
-                        if (f >= 10000 && f <= 30000000) return true;
+                        if (f >= adminReceiverMinHz() && f <= adminReceiverMaxHz()) return true;
                         skippedFreq++;
                         return false;
                     });
@@ -6979,7 +6990,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                 if (!file.name.endsWith('.json')) {
                     importedBookmarks = importedBookmarks.filter(b => {
                         const f = Number(b.frequency);
-                        if (f >= 10000 && f <= 30000000) return true;
+                        if (f >= adminReceiverMinHz() && f <= adminReceiverMaxHz()) return true;
                         skippedFreq++;
                         return false;
                     });
@@ -6987,7 +6998,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
 
                 if (importedBookmarks.length === 0) {
                     const msg = skippedFreq > 0
-                        ? `No valid bookmarks found in file (${skippedFreq} skipped: outside 10 kHz – 30 MHz range)`
+                        ? `No valid bookmarks found in file (${skippedFreq} skipped: outside ${adminReceiverRangeLabel()})`
                         : 'No valid bookmarks found in file';
                     showAlert(msg, 'error');
                     return;
@@ -7024,7 +7035,7 @@ frame.contentWindow.postMessage({ command: 'getState', params: {} }, SDR_ORIGIN)
                 await loadBookmarks();
                 let successMsg = `Successfully imported ${importedBookmarks.length} bookmark(s) (${importMode})`;
                 const totalSkipped = skippedFreq + serverSkipped;
-                if (totalSkipped > 0) successMsg += ` — ${totalSkipped} skipped (outside 10 kHz – 30 MHz)`;
+                if (totalSkipped > 0) successMsg += ` — ${totalSkipped} skipped (outside ${adminReceiverRangeLabel()})`;
                 showAlert(successMsg, 'success');
             } catch (error) {
                 showAlert('Error importing bookmarks: ' + error.message, 'error');

--- a/static/app.js
+++ b/static/app.js
@@ -19,6 +19,47 @@ import { screenWakeLock } from './wake-lock.js';
 // navigated to the page with those parameters.
 const initialPageParams = new URLSearchParams(window.location.search);
 
+// Receiver coverage is supplied by /api/description. Keep the legacy HF range
+// until that request resolves so older servers and offline UI tests retain the
+// previous behavior.
+window.receiverFrequencyRange = window.receiverFrequencyRange || {
+    minHz: 10000,
+    maxHz: 30000000
+};
+window.receiverSpectrumRange = window.receiverSpectrumRange || {
+    minHz: 10000,
+    maxHz: 30000000
+};
+
+function setReceiverFrequencyRange(receiver) {
+    const minHz = Number(receiver?.frequency_min_hz);
+    const maxHz = Number(receiver?.frequency_max_hz);
+    if (Number.isFinite(minHz) && Number.isFinite(maxHz) && minHz >= 0 && maxHz > minHz) {
+        window.receiverFrequencyRange = { minHz, maxHz };
+    }
+    const spectrumMinHz = Number(receiver?.spectrum_min_hz);
+    const spectrumMaxHz = Number(receiver?.spectrum_max_hz);
+    if (Number.isFinite(spectrumMinHz) && Number.isFinite(spectrumMaxHz) &&
+        spectrumMinHz >= minHz && spectrumMaxHz <= maxHz && spectrumMaxHz > spectrumMinHz) {
+        window.receiverSpectrumRange = { minHz: spectrumMinHz, maxHz: spectrumMaxHz };
+    } else {
+        window.receiverSpectrumRange = { ...window.receiverFrequencyRange };
+    }
+}
+
+function receiverMinFrequencyHz() {
+    return window.receiverFrequencyRange?.minHz ?? 10000;
+}
+
+function receiverMaxFrequencyHz() {
+    return window.receiverFrequencyRange?.maxHz ?? 30000000;
+}
+
+window.receiverMinFrequencyHz = receiverMinFrequencyHz;
+window.receiverMaxFrequencyHz = receiverMaxFrequencyHz;
+window.receiverSpectrumMinHz = () => window.receiverSpectrumRange?.minHz ?? receiverMinFrequencyHz();
+window.receiverSpectrumMaxHz = () => window.receiverSpectrumRange?.maxHz ?? receiverMaxFrequencyHz();
+
 // Feature flag: set to true to re-enable the FM/NFM squelch UI panel and
 // the associated set_squelch server commands.  Currently disabled while the
 // squelch feature is under development.
@@ -3387,6 +3428,7 @@ async function fetchSiteDescription() {
             
             // Store instance description globally for use by other modules (e.g., recorder)
             window.instanceDescription = data;
+            setReceiverFrequencyRange(data.receiver);
 
             // Seed active antenna label from description and start polling if ant_switch enabled
             if (data.ant_switch && data.ant_switch.enabled) {
@@ -3420,9 +3462,20 @@ async function fetchSiteDescription() {
             // URL with the HTML default values before this async fetch resolved.
             const urlParams = initialPageParams;
 
-            if (data.default_frequency && !urlParams.has('freq')) {
+            if (urlParams.has('freq')) {
+                const requestedFreq = parseInt(urlParams.get('freq'));
+                if (!isNaN(requestedFreq) &&
+                    requestedFreq >= receiverMinFrequencyHz() &&
+                    requestedFreq <= receiverMaxFrequencyHz()) {
+                    setFrequencyInputValue(requestedFreq);
+                    updateBandButtons(requestedFreq);
+                    updateBandSelector();
+                }
+            } else if (data.default_frequency) {
                 const freq = parseInt(data.default_frequency);
-                if (!isNaN(freq) && freq >= 10000 && freq <= 30000000) {
+                if (!isNaN(freq) &&
+                    freq >= receiverMinFrequencyHz() &&
+                    freq <= receiverMaxFrequencyHz()) {
                     // Use setFrequencyInputValue so the display is updated correctly
                     // regardless of the current frequency unit (Hz/kHz/MHz).
                     setFrequencyInputValue(freq);
@@ -5978,7 +6031,7 @@ function tune() {
     }
 }
 
-// Validate frequency input - only allow digits and max 8 digits
+// Validate frequency input - only allow digits and enough digits for this receiver
 function validateFrequencyInput(input) {
     // Store cursor position before any changes
     const cursorPos = input.selectionStart;
@@ -5987,9 +6040,9 @@ function validateFrequencyInput(input) {
     // Remove any non-digit characters
     let value = oldValue.replace(/\D/g, '');
 
-    // Limit to 8 digits (max 30000000)
-    if (value.length > 8) {
-        value = value.substring(0, 8);
+    const maxDigits = receiverMaxFrequencyHz().toString().length;
+    if (value.length > maxDigits) {
+        value = value.substring(0, maxDigits);
     }
 
     // Only update if value actually changed (prevents unnecessary cursor resets)
@@ -6015,9 +6068,9 @@ function handleFrequencyChange() {
     const freqInput = document.getElementById('frequency');
     const valueStr = freqInput.value.trim();
 
-    // Don't validate incomplete input (less than 5 digits for 10 kHz minimum)
+    // Don't validate incomplete input while the user is still typing.
     // This prevents clamping while user is still typing
-    if (valueStr.length < 5) {
+    if (valueStr.length < receiverMinFrequencyHz().toString().length) {
         return;
     }
 
@@ -6028,9 +6081,8 @@ function handleFrequencyChange() {
     // Update page title
     updatePageTitle();
 
-    // Validate frequency range: 10 kHz to 30 MHz (in Hz)
-    const MIN_FREQ = 10000;    // 10 kHz
-    const MAX_FREQ = 30000000; // 30 MHz
+    const MIN_FREQ = receiverMinFrequencyHz();
+    const MAX_FREQ = receiverMaxFrequencyHz();
 
     if (isNaN(frequency) || frequency < MIN_FREQ || frequency > MAX_FREQ) {
         // Clamp to valid range
@@ -6100,8 +6152,8 @@ function handleFrequencyChange() {
 // Set frequency from preset button
 function setFrequency(freq) {
     // Validate frequency range
-    const MIN_FREQ = 10000;    // 10 kHz
-    const MAX_FREQ = 30000000; // 30 MHz
+    const MIN_FREQ = receiverMinFrequencyHz();
+    const MAX_FREQ = receiverMaxFrequencyHz();
 
     const clampedFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, freq));
 
@@ -6279,9 +6331,9 @@ function adjustFrequency(deltaHz) {
     const snapped   = Math.round(currentFreq / stepSize) * stepSize;
     const newFreq   = snapped + direction * stepSize;
 
-    // Clamp to valid range: 10 kHz to 30 MHz
-    const MIN_FREQ = 10000;    // 10 kHz
-    const MAX_FREQ = 30000000; // 30 MHz
+    // Clamp to the configured receiver coverage.
+    const MIN_FREQ = receiverMinFrequencyHz();
+    const MAX_FREQ = receiverMaxFrequencyHz();
     const roundedFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, newFreq));
 
     setFrequencyInputValue(roundedFreq);
@@ -6320,8 +6372,8 @@ function roundToNearestKHz() {
     const currentFreq = parseInt(freqInput.getAttribute('data-hz-value') || freqInput.value);
     const rounded = Math.round(currentFreq / 1000) * 1000;
 
-    const MIN_FREQ = 10000;
-    const MAX_FREQ = 30000000;
+    const MIN_FREQ = receiverMinFrequencyHz();
+    const MAX_FREQ = receiverMaxFrequencyHz();
     const clampedFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, rounded));
 
     setFrequencyInputValue(clampedFreq);
@@ -6347,7 +6399,9 @@ function loadSettingsFromURL() {
     // Load frequency
     if (params.has('freq')) {
         const freq = parseInt(params.get('freq'));
-        if (!isNaN(freq) && freq >= 10000 && freq <= 30000000) {
+        if (!isNaN(freq) &&
+            freq >= receiverMinFrequencyHz() &&
+            freq <= receiverMaxFrequencyHz()) {
             const freqInput = document.getElementById('frequency');
             if (freqInput && document.activeElement !== freqInput) {
                 // Store as Hz value directly (don't use setFrequencyInputValue yet as unit may not be loaded)
@@ -8784,9 +8838,9 @@ function performFrequencyShift() {
         newDialFreq = currentDialFreq + shiftAmount;
     }
 
-    // Clamp to valid range (10 kHz to 30 MHz)
-    const MIN_FREQ = 10000;
-    const MAX_FREQ = 30000000;
+    // Clamp to configured receiver coverage.
+    const MIN_FREQ = receiverMinFrequencyHz();
+    const MAX_FREQ = receiverMaxFrequencyHz();
     newDialFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, newDialFreq));
     newDialFreq = Math.round(newDialFreq);
 
@@ -8956,8 +9010,8 @@ function enableFrequencyTracking() {
                 }
 
                 // Clamp to valid range
-                const MIN_FREQ = 10000;
-                const MAX_FREQ = 30000000;
+                const MIN_FREQ = receiverMinFrequencyHz();
+                const MAX_FREQ = receiverMaxFrequencyHz();
                 newDialFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, newDialFreq));
                 newDialFreq = Math.round(newDialFreq);
 
@@ -9070,8 +9124,8 @@ function enableFrequencyTracking() {
         }
 
         // Clamp to valid range
-        const MIN_FREQ = 10000;
-        const MAX_FREQ = 30000000;
+        const MIN_FREQ = receiverMinFrequencyHz();
+        const MAX_FREQ = receiverMaxFrequencyHz();
         newDialFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, newDialFreq));
         newDialFreq = Math.round(newDialFreq);
 
@@ -11970,8 +12024,8 @@ function updateZoomSlider() {
     // Slider range = number of halvings from full span down to the UI zoom floor.
     //
     // Both terms scale as 1/binCount, so the ratio — and therefore the slider range —
-    // is the same for every spectrum.bin_count setting:
-    //   log2((30e6 / N) / (MIN_ZOOM_SPAN_HZ / N)) = log2(30e6 / 10240) ≈ 11.5 → 11
+    // is the same for every spectrum.bin_count setting. The initial bandwidth
+    // already reflects the active receiver's instantaneous spectrum span.
     //
     // floor() rather than round() so the top notch is the first position that
     // actually reaches the floor; rounding up would leave two notches on the same
@@ -16000,7 +16054,10 @@ window.updateChannelsMapPopup = updateChannelsMapPopup;
             const stepSize  = Math.abs(deltaHz);
             const direction = Math.sign(deltaHz);
             const snapped   = Math.round(currentHz / stepSize) * stepSize;
-            const newHz     = Math.max(10000, Math.min(30000000, snapped + direction * stepSize));
+            const newHz     = Math.max(
+                receiverMinFrequencyHz(),
+                Math.min(receiverMaxFrequencyHz(), snapped + direction * stepSize)
+            );
 
             setFrequencyInputValue(newHz);
             updateBandButtons(newHz);

--- a/static/band-freq-toggle.js
+++ b/static/band-freq-toggle.js
@@ -22,29 +22,36 @@ function updateFrequencyReadout() {
     const freqMHz = freqHz / 1000000;
     const freqStr = freqMHz.toFixed(6);
 
-    // Split into digits (format: XX.XXX.XXX - 2 whole, 3 decimal, 3 more decimal)
+    // Split into digits. The markup reserves five whole-MHz positions and
+    // hides unused leading positions, allowing the same readout to grow from
+    // HF through VHF/UHF/microwave frequencies.
     const parts = freqStr.split('.');
-    const wholePart = parts[0].padStart(2, '0'); // Ensure 2 digits (e.g., "14")
+    const wholePart = parts[0];
     const decimalPart = (parts[1] || '000000').padEnd(6, '0'); // Ensure exactly 6 decimal places
 
     // Update each digit
     const digits = document.querySelectorAll('.freq-digit');
+    const wholeDigitCount = Math.max(2, digits.length - 6);
+    const visibleWholeDigits = Math.max(2, Math.min(wholeDigitCount, wholePart.length));
+    const paddedWholePart = wholePart.padStart(wholeDigitCount, '0').slice(-wholeDigitCount);
 
-    // First 2 digits are the whole MHz part (e.g., "14")
-    if (digits[0]) digits[0].textContent = wholePart[0];
-    if (digits[1]) digits[1].textContent = wholePart[1];
+    for (let i = 0; i < wholeDigitCount; i++) {
+        if (!digits[i]) continue;
+        digits[i].textContent = paddedWholePart[i];
+        digits[i].style.display = i < wholeDigitCount - visibleWholeDigits ? 'none' : '';
+    }
 
     // Next 3 digits are the first part of decimal (e.g., "074")
     for (let i = 0; i < 3; i++) {
-        if (digits[i + 2]) {
-            digits[i + 2].textContent = decimalPart[i];
+        if (digits[i + wholeDigitCount]) {
+            digits[i + wholeDigitCount].textContent = decimalPart[i];
         }
     }
 
     // Last 3 digits are the final decimal part (e.g., "000")
     for (let i = 0; i < 3; i++) {
-        if (digits[i + 5]) {
-            digits[i + 5].textContent = decimalPart[i + 3];
+        if (digits[i + wholeDigitCount + 3]) {
+            digits[i + wholeDigitCount + 3].textContent = decimalPart[i + 3];
         }
     }
 }
@@ -143,8 +150,9 @@ function changeFrequencyByStep(step, increment) {
         currentFreq -= step;
     }
 
-    // Clamp frequency to reasonable bounds (10 kHz to 30 MHz for HF)
-    currentFreq = Math.max(10000, Math.min(30000000, currentFreq));
+    const minFrequency = window.receiverMinFrequencyHz?.() ?? 10000;
+    const maxFrequency = window.receiverMaxFrequencyHz?.() ?? 30000000;
+    currentFreq = Math.max(minFrequency, Math.min(maxFrequency, currentFreq));
 
     // Use the global setFrequencyInputValue function to properly update the input
     if (typeof window.setFrequencyInputValue === 'function') {

--- a/static/extensions/digitalvoice/main.js
+++ b/static/extensions/digitalvoice/main.js
@@ -1,0 +1,297 @@
+// Digital Voice extension — receive-only DSD-FME integration.
+//
+// Binary protocol (backend -> browser):
+//   0x40 [UTF-8 JSON] decoder event/metadata
+//   0x41 [timestamp:8 BE][sample rate:4 BE][channels:1][PCM16 LE...]
+//   0x42 [UTF-8 JSON] decoder error
+
+class DigitalVoiceExtension extends DecoderExtension {
+    constructor() {
+        super('digitalvoice', {
+            displayName: 'Digital Voice',
+            autoTune: false,
+            requiresMode: null,
+            preferredBandwidth: null
+        });
+        this.running = false;
+        this.eventCount = 0;
+        this.originalHandler = null;
+        this.binaryHandler = null;
+        this.nextPlayTime = 0;
+        this.gainNode = null;
+        this.handlersReady = false;
+    }
+
+    onInitialize() {
+        this._render();
+        this._bind();
+    }
+
+    onActivate() {
+        this.handlersReady = false;
+        this._bind();
+    }
+
+    onDeactivate() {
+        if (this.running) this._stop();
+    }
+
+    onDisable() {
+        if (this.running) this._stop();
+        this._restoreWebSocket();
+    }
+
+    onProcessAudio(_samples) {}
+
+    _render() {
+        const container = document.querySelector('.extension-content[data-extension="digitalvoice"]');
+        if (container && window.digitalvoice_template) {
+            container.innerHTML = window.digitalvoice_template;
+        }
+    }
+
+    _bind() {
+        if (this.handlersReady) return;
+        const start = document.getElementById('dv-start');
+        if (!start) {
+            setTimeout(() => this._bind(), 100);
+            return;
+        }
+        this.handlersReady = true;
+        start.addEventListener('click', () => this.running ? this._stop() : this._start());
+        document.getElementById('dv-clear')?.addEventListener('click', () => this._clear());
+        document.getElementById('dv-protocol')?.addEventListener('change', () => this._updateInversion());
+        document.getElementById('dv-volume')?.addEventListener('input', (event) => {
+            if (this.gainNode) this.gainNode.gain.value = Number(event.target.value);
+        });
+        this._updateInversion();
+    }
+
+    _updateInversion() {
+        const protocol = document.getElementById('dv-protocol')?.value || 'dmr';
+        const checkbox = document.getElementById('dv-inverted');
+        if (!checkbox) return;
+        checkbox.disabled = !['dmr', 'nxdn48', 'nxdn96', 'dpmr', 'm17'].includes(protocol);
+        if (checkbox.disabled) checkbox.checked = false;
+    }
+
+    async _start() {
+        const ws = this._webSocket();
+        if (!ws) {
+            this._setStatus('Audio connection is not ready', 'error');
+            return;
+        }
+
+        const protocol = document.getElementById('dv-protocol')?.value || 'dmr';
+        const bandwidths = {
+            nxdn48: 7000, dpmr: 7000,
+            provoice: 24000, edacs: 24000
+        };
+        const width = bandwidths[protocol] || 12000;
+
+        // The server-side decoder consumes the mono NFM audio tap. Allow the
+        // mode update to reach the receiver before attaching the extension.
+        if ((this.radio.getMode() || '').toLowerCase() !== 'nfm') {
+            this.radio.setMode('nfm');
+        }
+        this.radio.setBandwidth(-Math.floor(width / 2), Math.floor(width / 2));
+        await new Promise(resolve => setTimeout(resolve, 350));
+
+        this._installWebSocket();
+        ws.send(JSON.stringify({
+            type: 'audio_extension_attach',
+            extension_name: 'digitalvoice',
+            params: {
+                protocol,
+                inverted: !!document.getElementById('dv-inverted')?.checked
+            }
+        }));
+
+        this.running = true;
+        this.nextPlayTime = 0;
+        this._setButton(true);
+        this._setStatus('Starting…', 'running');
+    }
+
+    _stop() {
+        const ws = this._webSocket();
+        if (ws) ws.send(JSON.stringify({ type: 'audio_extension_detach' }));
+        this.running = false;
+        this.nextPlayTime = 0;
+        this._setButton(false);
+        this._setStatus('Stopped', '');
+        this._restoreWebSocket();
+    }
+
+    _webSocket() {
+        const ws = window.dxClusterClient?.ws;
+        return ws && ws.readyState === WebSocket.OPEN ? ws : null;
+    }
+
+    _installWebSocket() {
+        const client = window.dxClusterClient;
+        if (!client?.ws) return;
+        if (!this.originalHandler) this.originalHandler = client.ws.onmessage;
+        client.ws.binaryType = 'arraybuffer';
+        this.binaryHandler = (event) => {
+            if (event.data instanceof ArrayBuffer) {
+                this._handleBinary(event.data);
+                return;
+            }
+            if (event.data instanceof Blob) {
+                event.data.arrayBuffer().then(data => this._handleBinary(data));
+                return;
+            }
+            try {
+                const message = JSON.parse(event.data);
+                if (message.type === 'audio_extension_attached' &&
+                    message.extension_name === 'digitalvoice') {
+                    this._setStatus('Running — waiting for a signal…', 'running');
+                    return;
+                }
+                if (message.type === 'audio_extension_error') {
+                    this._handleError(message.error || 'Decoder error');
+                    return;
+                }
+            } catch (_) {
+                // Forward non-JSON text below.
+            }
+            if (this.originalHandler) this.originalHandler.call(client.ws, event);
+        };
+        client.ws.onmessage = this.binaryHandler;
+    }
+
+    _restoreWebSocket() {
+        const client = window.dxClusterClient;
+        if (client?.ws && this.originalHandler) {
+            client.ws.onmessage = this.originalHandler;
+            client.ws.binaryType = 'blob';
+        }
+        this.originalHandler = null;
+        this.binaryHandler = null;
+    }
+
+    _handleBinary(data) {
+        if (!data || data.byteLength < 1) return;
+        const type = new DataView(data).getUint8(0);
+        if (type === 0x40 || type === 0x42) {
+            const payload = new TextDecoder().decode(new Uint8Array(data, 1));
+            try {
+                const message = JSON.parse(payload);
+                if (type === 0x42) this._handleError(message.error || 'DSD-FME stopped');
+                else this._addEvent(message);
+            } catch (error) {
+                console.warn('[DigitalVoice] invalid event payload', error);
+            }
+            return;
+        }
+        if (type === 0x41) this._playPCM(data);
+    }
+
+    _playPCM(data) {
+        if (!this.running || data.byteLength < 16) return;
+        const view = new DataView(data);
+        const sampleRate = view.getUint32(9, false);
+        const channels = view.getUint8(13);
+        const byteLength = data.byteLength - 14;
+        const frames = Math.floor(byteLength / (2 * channels));
+        if (!sampleRate || !channels || !frames) return;
+
+        const context = this.radio.getAudioContext();
+        if (!context) return;
+        if (!this.gainNode) {
+            this.gainNode = context.createGain();
+            this.gainNode.gain.value = Number(document.getElementById('dv-volume')?.value || 1);
+            this.gainNode.connect(context.destination);
+        }
+
+        const buffer = context.createBuffer(channels, frames, sampleRate);
+        for (let channel = 0; channel < channels; channel++) {
+            const output = buffer.getChannelData(channel);
+            for (let frame = 0; frame < frames; frame++) {
+                const offset = 14 + ((frame * channels + channel) * 2);
+                output[frame] = view.getInt16(offset, true) / 32768;
+            }
+        }
+
+        const now = context.currentTime;
+        if (this.nextPlayTime < now || this.nextPlayTime > now + 1) {
+            this.nextPlayTime = now + 0.06;
+        }
+        const source = context.createBufferSource();
+        source.buffer = buffer;
+        source.connect(this.gainNode);
+        source.start(this.nextPlayTime);
+        this.nextPlayTime += frames / sampleRate;
+        this._setStatus('Decoding clear audio', 'running');
+    }
+
+    _addEvent(event) {
+        if (event.type === 'digital_voice_started') {
+            this._setStatus('Running — waiting for a signal…', 'running');
+            return;
+        }
+        this.eventCount += 1;
+        const count = document.getElementById('dv-count');
+        if (count) count.textContent = `${this.eventCount} event${this.eventCount === 1 ? '' : 's'}`;
+
+        const list = document.getElementById('dv-events');
+        if (!list) return;
+        list.querySelector('.dv-empty')?.remove();
+        const row = document.createElement('div');
+        row.className = `dv-event${event.encrypted ? ' encrypted' : ''}`;
+
+        const header = document.createElement('div');
+        header.className = 'dv-event-head';
+        const details = [String(event.protocol || 'signal').toUpperCase()];
+        if (event.slot) details.push(`slot ${event.slot}`);
+        if (event.color_code !== undefined && event.color_code !== 0) details.push(`CC ${event.color_code}`);
+        if (event.source_id) details.push(`source ${event.source_id}`);
+        if (event.target_id) details.push(`target ${event.target_id}`);
+        if (event.nac) details.push(`NAC ${event.nac}`);
+        if (event.encrypted) details.push('ENCRYPTED — AUDIO SUPPRESSED');
+        header.textContent = details.join(' · ');
+
+        const body = document.createElement('div');
+        body.textContent = event.raw || '';
+        row.append(header, body);
+        list.prepend(row);
+        while (list.children.length > 200) list.lastElementChild.remove();
+    }
+
+    _handleError(message) {
+        this.running = false;
+        this._setButton(false);
+        this._setStatus(message, 'error');
+        this._restoreWebSocket();
+    }
+
+    _setButton(running) {
+        const button = document.getElementById('dv-start');
+        if (!button) return;
+        button.textContent = running ? 'Stop decoder' : 'Start decoder';
+        button.classList.toggle('running', running);
+    }
+
+    _setStatus(text, className) {
+        const status = document.getElementById('dv-status');
+        if (!status) return;
+        status.textContent = text;
+        status.className = `dv-status${className ? ` ${className}` : ''}`;
+    }
+
+    _clear() {
+        this.eventCount = 0;
+        const count = document.getElementById('dv-count');
+        if (count) count.textContent = '0 events';
+        const list = document.getElementById('dv-events');
+        if (list) list.innerHTML = '<div class="dv-empty">Waiting for decoder events.</div>';
+    }
+}
+
+if (window.decoderManager) {
+    window.decoderManager.register(new DigitalVoiceExtension());
+    console.log('Digital Voice extension registered');
+} else {
+    console.error('[DigitalVoice] decoderManager not available');
+}

--- a/static/extensions/digitalvoice/manifest.json
+++ b/static/extensions/digitalvoice/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "digitalvoice",
+  "displayName": "Digital Voice",
+  "version": "1.0.0",
+  "description": "Receive-only DMR, P25, NXDN, D-Star, YSF, M17, dPMR, ProVoice/EDACS and X2-TDMA decoding through DSD-FME.",
+  "author": "UberSDR",
+  "type": "decoder",
+  "icon": "📻",
+  "category": "decoder",
+  "requiresAudio": true,
+  "defaultEnabled": false,
+  "files": {
+    "main": "main.js",
+    "styles": ["styles.css"],
+    "template": "template.html"
+  },
+  "settings": {}
+}

--- a/static/extensions/digitalvoice/styles.css
+++ b/static/extensions/digitalvoice/styles.css
@@ -1,0 +1,115 @@
+.dv-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  color: var(--text-color, #ddd);
+}
+
+.dv-controls {
+  display: flex;
+  align-items: end;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.dv-controls label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.dv-controls select,
+.dv-controls button {
+  min-height: 34px;
+}
+
+.dv-controls button {
+  padding: 6px 14px;
+  border: 0;
+  border-radius: 4px;
+  cursor: pointer;
+  color: #fff;
+  background: #2e7d32;
+}
+
+.dv-controls button.running {
+  background: #b71c1c;
+}
+
+.dv-controls button.secondary {
+  background: #555;
+}
+
+.dv-controls .dv-check {
+  flex-direction: row;
+  align-items: center;
+  min-height: 34px;
+}
+
+.dv-volume input {
+  width: 120px;
+}
+
+.dv-status-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  font-size: 13px;
+}
+
+.dv-status.running {
+  color: #66bb6a;
+}
+
+.dv-status.error {
+  color: #ef5350;
+}
+
+.dv-notice {
+  padding: 8px 10px;
+  border-left: 3px solid #607d8b;
+  background: rgba(96, 125, 139, 0.14);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.dv-events {
+  min-height: 220px;
+  max-height: 430px;
+  overflow: auto;
+  border: 1px solid rgba(127, 127, 127, 0.35);
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.25);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+}
+
+.dv-event {
+  padding: 7px 9px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.18);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.dv-event.encrypted {
+  border-left: 3px solid #ef5350;
+  background: rgba(239, 83, 80, 0.09);
+}
+
+.dv-event-head {
+  margin-bottom: 3px;
+  color: #90caf9;
+  font-weight: 600;
+}
+
+.dv-event.encrypted .dv-event-head {
+  color: #ef9a9a;
+}
+
+.dv-empty {
+  padding: 22px;
+  color: #999;
+  text-align: center;
+}

--- a/static/extensions/digitalvoice/template.html
+++ b/static/extensions/digitalvoice/template.html
@@ -1,0 +1,46 @@
+<div class="dv-container">
+  <div class="dv-controls">
+    <label>
+      Protocol
+      <select id="dv-protocol">
+        <option value="auto">Auto (DMR / P25 / YSF / D-Star / X2)</option>
+        <option value="dmr" selected>DMR</option>
+        <option value="p25p1">P25 Phase 1</option>
+        <option value="p25p2">P25 Phase 2</option>
+        <option value="nxdn48">NXDN48 / IDAS</option>
+        <option value="nxdn96">NXDN96</option>
+        <option value="dstar">D-Star</option>
+        <option value="ysf">YSF</option>
+        <option value="m17">M17</option>
+        <option value="dpmr">dPMR</option>
+        <option value="provoice">ProVoice</option>
+        <option value="edacs">EDACS / ProVoice</option>
+        <option value="x2tdma">X2-TDMA</option>
+      </select>
+    </label>
+    <label class="dv-check">
+      <input id="dv-inverted" type="checkbox">
+      Inverted signal
+    </label>
+    <label class="dv-volume">
+      Decoded volume
+      <input id="dv-volume" type="range" min="0" max="1.5" value="1" step="0.05">
+    </label>
+    <button id="dv-start" type="button">Start decoder</button>
+    <button id="dv-clear" type="button" class="secondary">Clear</button>
+  </div>
+
+  <div class="dv-status-row">
+    <span id="dv-status" class="dv-status">Stopped</span>
+    <span id="dv-count">0 events</span>
+  </div>
+
+  <div class="dv-notice">
+    Tune the signal in NFM with a clean discriminator/baseband level. This
+    extension decodes clear traffic only; it accepts no encryption or privacy keys.
+  </div>
+
+  <div id="dv-events" class="dv-events">
+    <div class="dv-empty">Press Start decoder and tune to a digital voice signal.</div>
+  </div>
+</div>

--- a/static/extensions/signalling/main.js
+++ b/static/extensions/signalling/main.js
@@ -1,0 +1,202 @@
+// Paging & Signalling extension — multimon-ng integration.
+// Backend messages: 0x50 JSON decode/event, 0x51 JSON error.
+
+class SignallingExtension extends DecoderExtension {
+    constructor() {
+        super('signalling', {
+            displayName: 'Paging & Signalling',
+            autoTune: false,
+            requiresMode: null,
+            preferredBandwidth: null
+        });
+        this.running = false;
+        this.decodeCount = 0;
+        this.originalHandler = null;
+        this.handlersReady = false;
+    }
+
+    onInitialize() {
+        const container = document.querySelector('.extension-content[data-extension="signalling"]');
+        if (container && window.signalling_template) container.innerHTML = window.signalling_template;
+        this._bind();
+    }
+
+    onActivate() {
+        this.handlersReady = false;
+        this._bind();
+    }
+
+    onDeactivate() {
+        if (this.running) this._stop();
+    }
+
+    onDisable() {
+        if (this.running) this._stop();
+        this._restoreWebSocket();
+    }
+
+    onProcessAudio(_samples) {}
+
+    _bind() {
+        if (this.handlersReady) return;
+        const start = document.getElementById('sig-start');
+        if (!start) {
+            setTimeout(() => this._bind(), 100);
+            return;
+        }
+        this.handlersReady = true;
+        start.addEventListener('click', () => this.running ? this._stop() : this._start());
+        document.getElementById('sig-clear')?.addEventListener('click', () => this._clear());
+    }
+
+    async _start() {
+        const ws = this._webSocket();
+        if (!ws) {
+            this._setStatus('Audio connection is not ready', 'error');
+            return;
+        }
+        const profile = document.getElementById('sig-profile')?.value || 'paging';
+        const bandwidth = profile === 'dtmf' || profile === 'twotone' ? 12000 : 15000;
+        if ((this.radio.getMode() || '').toLowerCase() !== 'nfm') this.radio.setMode('nfm');
+        this.radio.setBandwidth(-Math.floor(bandwidth / 2), Math.floor(bandwidth / 2));
+        await new Promise(resolve => setTimeout(resolve, 350));
+
+        this._installWebSocket();
+        ws.send(JSON.stringify({
+            type: 'audio_extension_attach',
+            extension_name: 'signalling',
+            params: { profile }
+        }));
+        this.running = true;
+        this._setButton(true);
+        this._setStatus('Starting…', 'running');
+    }
+
+    _stop() {
+        const ws = this._webSocket();
+        if (ws) ws.send(JSON.stringify({ type: 'audio_extension_detach' }));
+        this.running = false;
+        this._setButton(false);
+        this._setStatus('Stopped', '');
+        this._restoreWebSocket();
+    }
+
+    _webSocket() {
+        const ws = window.dxClusterClient?.ws;
+        return ws && ws.readyState === WebSocket.OPEN ? ws : null;
+    }
+
+    _installWebSocket() {
+        const client = window.dxClusterClient;
+        if (!client?.ws) return;
+        if (!this.originalHandler) this.originalHandler = client.ws.onmessage;
+        client.ws.binaryType = 'arraybuffer';
+        client.ws.onmessage = (event) => {
+            if (event.data instanceof ArrayBuffer) {
+                this._handleBinary(event.data);
+                return;
+            }
+            if (event.data instanceof Blob) {
+                event.data.arrayBuffer().then(data => this._handleBinary(data));
+                return;
+            }
+            try {
+                const message = JSON.parse(event.data);
+                if (message.type === 'audio_extension_attached' &&
+                    message.extension_name === 'signalling') {
+                    this._setStatus('Running — waiting for a signal…', 'running');
+                    return;
+                }
+                if (message.type === 'audio_extension_error') {
+                    this._handleError(message.error || 'Decoder error');
+                    return;
+                }
+            } catch (_) {
+                // Forward non-JSON text below.
+            }
+            if (this.originalHandler) this.originalHandler.call(client.ws, event);
+        };
+    }
+
+    _restoreWebSocket() {
+        const client = window.dxClusterClient;
+        if (client?.ws && this.originalHandler) {
+            client.ws.onmessage = this.originalHandler;
+            client.ws.binaryType = 'blob';
+        }
+        this.originalHandler = null;
+    }
+
+    _handleBinary(data) {
+        if (!data || data.byteLength < 2) return;
+        const type = new DataView(data).getUint8(0);
+        if (type !== 0x50 && type !== 0x51) return;
+        try {
+            const payload = new TextDecoder().decode(new Uint8Array(data, 1));
+            const message = JSON.parse(payload);
+            if (type === 0x51) this._handleError(message.error || 'multimon-ng stopped');
+            else if (message.type === 'signalling_started') {
+                this._setStatus('Running — waiting for a signal…', 'running');
+            } else {
+                this._addDecode(message);
+            }
+        } catch (error) {
+            console.warn('[Signalling] invalid decoder payload', error);
+        }
+    }
+
+    _addDecode(message) {
+        this.decodeCount += 1;
+        const count = document.getElementById('sig-count');
+        if (count) count.textContent = `${this.decodeCount} decode${this.decodeCount === 1 ? '' : 's'}`;
+        const list = document.getElementById('sig-results');
+        if (!list) return;
+        list.querySelector('.sig-empty')?.remove();
+        const row = document.createElement('div');
+        row.className = 'sig-result';
+        const stamp = document.createElement('span');
+        stamp.className = 'sig-time';
+        stamp.textContent = new Date(message.timestamp || Date.now()).toLocaleTimeString();
+        const text = document.createElement('span');
+        text.textContent = message.raw || '';
+        row.append(stamp, text);
+        list.prepend(row);
+        while (list.children.length > 300) list.lastElementChild.remove();
+    }
+
+    _handleError(message) {
+        this.running = false;
+        this._setButton(false);
+        this._setStatus(message, 'error');
+        this._restoreWebSocket();
+    }
+
+    _setButton(running) {
+        const button = document.getElementById('sig-start');
+        if (!button) return;
+        button.textContent = running ? 'Stop decoder' : 'Start decoder';
+        button.classList.toggle('running', running);
+    }
+
+    _setStatus(text, className) {
+        const status = document.getElementById('sig-status');
+        if (!status) return;
+        status.textContent = text;
+        status.className = className || '';
+    }
+
+    _clear() {
+        this.decodeCount = 0;
+        const count = document.getElementById('sig-count');
+        if (count) count.textContent = '0 decodes';
+        const list = document.getElementById('sig-results');
+        if (list) list.innerHTML = '<div class="sig-empty">Waiting for decoder output.</div>';
+    }
+}
+
+if (window.decoderManager) {
+    window.decoderManager.register(new SignallingExtension());
+    console.log('Paging & Signalling extension registered');
+} else {
+    console.error('[Signalling] decoderManager not available');
+}

--- a/static/extensions/signalling/manifest.json
+++ b/static/extensions/signalling/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "signalling",
+  "displayName": "Paging & Signalling",
+  "version": "1.0.0",
+  "description": "POCSAG/FLEX paging, SAME/EAS, DTMF, two-tone selective calling and legacy telemetry decoding.",
+  "author": "UberSDR",
+  "type": "decoder",
+  "icon": "📟",
+  "category": "decoder",
+  "requiresAudio": true,
+  "defaultEnabled": false,
+  "files": {
+    "main": "main.js",
+    "styles": ["styles.css"],
+    "template": "template.html"
+  },
+  "settings": {}
+}

--- a/static/extensions/signalling/styles.css
+++ b/static/extensions/signalling/styles.css
@@ -1,0 +1,15 @@
+.sig-container { display:flex; flex-direction:column; gap:12px; padding:12px; color:var(--text-color,#ddd); }
+.sig-controls { display:flex; align-items:end; flex-wrap:wrap; gap:10px; }
+.sig-controls label { display:flex; flex-direction:column; gap:4px; font-size:12px; }
+.sig-controls select, .sig-controls button { min-height:34px; }
+.sig-controls button { padding:6px 14px; border:0; border-radius:4px; cursor:pointer; color:#fff; background:#2e7d32; }
+.sig-controls button.running { background:#b71c1c; }
+.sig-controls button.secondary { background:#555; }
+.sig-status-row { display:flex; justify-content:space-between; gap:12px; font-size:13px; }
+#sig-status.running { color:#66bb6a; }
+#sig-status.error { color:#ef5350; }
+.sig-notice { padding:8px 10px; border-left:3px solid #607d8b; background:rgba(96,125,139,.14); font-size:12px; line-height:1.4; }
+.sig-results { min-height:220px; max-height:430px; overflow:auto; border:1px solid rgba(127,127,127,.35); border-radius:4px; background:rgba(0,0,0,.25); font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace; font-size:12px; }
+.sig-result { display:grid; grid-template-columns:90px 1fr; gap:8px; padding:7px 9px; border-bottom:1px solid rgba(127,127,127,.18); white-space:pre-wrap; overflow-wrap:anywhere; }
+.sig-time { color:#90caf9; }
+.sig-empty { padding:22px; color:#999; text-align:center; }

--- a/static/extensions/signalling/template.html
+++ b/static/extensions/signalling/template.html
@@ -1,0 +1,30 @@
+<div class="sig-container">
+  <div class="sig-controls">
+    <label>
+      Decoder set
+      <select id="sig-profile">
+        <option value="paging" selected>Paging (POCSAG + FLEX)</option>
+        <option value="pocsag">POCSAG</option>
+        <option value="flex">FLEX</option>
+        <option value="eas">SAME / EAS</option>
+        <option value="dtmf">DTMF</option>
+        <option value="twotone">Two-tone selective calling</option>
+        <option value="telemetry">Legacy telemetry</option>
+        <option value="all">Auto / all signalling</option>
+      </select>
+    </label>
+    <button id="sig-start" type="button">Start decoder</button>
+    <button id="sig-clear" type="button" class="secondary">Clear</button>
+  </div>
+  <div class="sig-status-row">
+    <span id="sig-status">Stopped</span>
+    <span id="sig-count">0 decodes</span>
+  </div>
+  <div class="sig-notice">
+    Tune the signal in NFM. The decoder automatically selects a suitable
+    bandwidth and supports receive-only, unencrypted over-the-air signalling.
+  </div>
+  <div id="sig-results" class="sig-results">
+    <div class="sig-empty">Press Start decoder and tune to a signalling channel.</div>
+  </div>
+</div>

--- a/static/index.html
+++ b/static/index.html
@@ -561,16 +561,19 @@
             <div class="control-group">
                 <div id="freq-readout-container" class="freq-readout-container">
                     <div class="freq-readout-display">
-                        <span class="freq-digit" data-position="0" data-step="10000000">0</span>
-                        <span class="freq-digit" data-position="1" data-step="1000000">0</span>
+                        <span class="freq-digit freq-digit-high" data-position="0" data-step="10000000000" style="display: none;">0</span>
+                        <span class="freq-digit freq-digit-high" data-position="1" data-step="1000000000" style="display: none;">0</span>
+                        <span class="freq-digit freq-digit-high" data-position="2" data-step="100000000" style="display: none;">0</span>
+                        <span class="freq-digit" data-position="3" data-step="10000000">0</span>
+                        <span class="freq-digit" data-position="4" data-step="1000000">0</span>
                         <span class="freq-separator">.</span>
-                        <span class="freq-digit" data-position="2" data-step="100000">0</span>
-                        <span class="freq-digit" data-position="3" data-step="10000">0</span>
-                        <span class="freq-digit" data-position="4" data-step="1000">0</span>
+                        <span class="freq-digit" data-position="5" data-step="100000">0</span>
+                        <span class="freq-digit" data-position="6" data-step="10000">0</span>
+                        <span class="freq-digit" data-position="7" data-step="1000">0</span>
                         <span class="freq-separator">.</span>
-                        <span class="freq-digit" data-position="5" data-step="100">0</span>
-                        <span class="freq-digit" data-position="6" data-step="10">0</span>
-                        <span class="freq-digit" data-position="7" data-step="1">0</span>
+                        <span class="freq-digit" data-position="8" data-step="100">0</span>
+                        <span class="freq-digit" data-position="9" data-step="10">0</span>
+                        <span class="freq-digit" data-position="10" data-step="1">0</span>
                         <span class="freq-unit-label">MHz</span>
                     </div>
                 </div>

--- a/static/spectrum-display.js
+++ b/static/spectrum-display.js
@@ -3107,10 +3107,10 @@ class SpectrumDisplay {
                 const freqDelta = -deltaX * freqPerPixel;
                 let newCenterFreq = lineGraphDragStartFreq + freqDelta;
 
-                // Apply boundary constraints (0-30 MHz)
+                // Apply configured receiver boundary constraints.
                 const halfBandwidth = this.totalBandwidth / 2;
-                const minCenterFreq = 0 + halfBandwidth;
-                const maxCenterFreq = 30e6 - halfBandwidth;
+                const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+                const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
 
                 // Clamp to boundaries
                 newCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
@@ -3158,10 +3158,12 @@ class SpectrumDisplay {
         this.lineGraphCanvas.addEventListener('mousedown', (e) => {
             if (!this.spectrumData) return;
 
-            // Check if we're showing full bandwidth (0-30 MHz)
+            // Check if we're showing full receiver coverage.
             const startFreq = this.centerFreq - this.totalBandwidth / 2;
             const endFreq = this.centerFreq + this.totalBandwidth / 2;
-            const isFullBandwidth = (startFreq <= 0 && endFreq >= 30e6);
+            const isFullBandwidth =
+                startFreq <= (window.receiverMinFrequencyHz?.() ?? 10000) &&
+                endFreq >= (window.receiverMaxFrequencyHz?.() ?? 30000000);
 
             if (isFullBandwidth) {
                 // Don't start dragging if showing full bandwidth
@@ -3294,10 +3296,12 @@ class SpectrumDisplay {
     updateLineGraphCursorStyle() {
         if (!this.lineGraphCanvas || !this.totalBandwidth) return;
 
-        // Check if we're showing full bandwidth (0-30 MHz)
+        // Check if we're showing full receiver coverage.
         const startFreq = this.centerFreq - this.totalBandwidth / 2;
         const endFreq = this.centerFreq + this.totalBandwidth / 2;
-        const isFullBandwidth = (startFreq <= 0 && endFreq >= 30e6);
+        const isFullBandwidth =
+            startFreq <= (window.receiverMinFrequencyHz?.() ?? 10000) &&
+            endFreq >= (window.receiverMaxFrequencyHz?.() ?? 30000000);
 
         // Set cursor based on whether dragging is allowed
         this.lineGraphCanvas.style.cursor = 'default';
@@ -4620,10 +4624,10 @@ class SpectrumDisplay {
                 const freqDelta = -deltaX * freqPerPixel;
                 let newCenterFreq = this.dragStartFreq + freqDelta;
 
-                // Apply boundary constraints (0-30 MHz)
+                // Apply configured receiver boundary constraints.
                 const halfBandwidth = this.totalBandwidth / 2;
-                const minCenterFreq = 0 + halfBandwidth;
-                const maxCenterFreq = 30e6 - halfBandwidth;
+                const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+                const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
 
                 // Clamp to boundaries
                 newCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
@@ -4664,11 +4668,13 @@ class SpectrumDisplay {
         this.canvas.addEventListener('mousedown', (e) => {
             if (!this.spectrumData) return;
 
-            // Check if we're showing full bandwidth (0-30 MHz)
+            // Check if we're showing full receiver coverage.
             // If so, don't allow dragging
             const startFreq = this.centerFreq - this.totalBandwidth / 2;
             const endFreq = this.centerFreq + this.totalBandwidth / 2;
-            const isFullBandwidth = (startFreq <= 0 && endFreq >= 30e6);
+            const isFullBandwidth =
+                startFreq <= (window.receiverMinFrequencyHz?.() ?? 10000) &&
+                endFreq >= (window.receiverMaxFrequencyHz?.() ?? 30000000);
 
             if (isFullBandwidth) {
                 // Don't start dragging if showing full bandwidth
@@ -4884,10 +4890,10 @@ class SpectrumDisplay {
                 const newTotalBW = newBinBandwidth * this.binCount;
                 const newCenterFreq = touchFreq;
 
-                // Constrain to 0-30 MHz
+                // Constrain to configured receiver coverage.
                 const halfBandwidth = newTotalBW / 2;
-                const minCenterFreq = 0 + halfBandwidth;
-                const maxCenterFreq = 30e6 - halfBandwidth;
+                const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+                const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
                 const clampedCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
 
                 // Send zoom request
@@ -4921,8 +4927,8 @@ class SpectrumDisplay {
 
                 // Apply boundary constraints
                 const halfBandwidth = this.totalBandwidth / 2;
-                const minCenterFreq = 0 + halfBandwidth;
-                const maxCenterFreq = 30e6 - halfBandwidth;
+                const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+                const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
                 newCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
 
                 // Send pan request (throttled)
@@ -5442,9 +5448,9 @@ class SpectrumDisplay {
                 // Round to nearest step size for clean values
                 newFreq = Math.round(newFreq / step) * step;
 
-                // Clamp to valid range (10 kHz to 30 MHz)
-                const MIN_FREQ = 10000;
-                const MAX_FREQ = 30000000;
+                // Clamp to the coverage advertised by the active receiver.
+                const MIN_FREQ = window.receiverMinFrequencyHz?.() ?? 10000;
+                const MAX_FREQ = window.receiverMaxFrequencyHz?.() ?? 30000000;
                 newFreq = Math.max(MIN_FREQ, Math.min(MAX_FREQ, newFreq));
                 
                 // Update frequency input
@@ -5494,10 +5500,12 @@ class SpectrumDisplay {
     updateCursorStyle() {
         if (!this.canvas || !this.totalBandwidth) return;
 
-        // Check if we're showing full bandwidth (0-30 MHz)
+        // Check if we're showing full receiver coverage.
         const startFreq = this.centerFreq - this.totalBandwidth / 2;
         const endFreq = this.centerFreq + this.totalBandwidth / 2;
-        const isFullBandwidth = (startFreq <= 0 && endFreq >= 30e6);
+        const isFullBandwidth =
+            startFreq <= (window.receiverMinFrequencyHz?.() ?? 10000) &&
+            endFreq >= (window.receiverMaxFrequencyHz?.() ?? 30000000);
 
         // Set cursor based on whether dragging is allowed
         this.canvas.style.cursor = 'default';
@@ -5675,12 +5683,14 @@ class SpectrumDisplay {
         return Math.max(0.5, MIN_ZOOM_SPAN_HZ / bins);
     }
 
-    // Bin bandwidth at full zoom-out (the whole 0-30 MHz span). Prefers the value
+    // Bin bandwidth at full zoom-out (the whole configured receiver span). Prefers the value
     // the server reports; falls back to deriving it from the bin count.
     fullSpanBinBandwidth() {
         if (this.defaultBinBandwidth > 0) return this.defaultBinBandwidth;
         if (this.initialBinBandwidth > 0) return this.initialBinBandwidth;
-        return 30000000 / (this.defaultBinCount || this.binCount || 1024);
+        const minHz = window.receiverSpectrumMinHz?.() ?? 10000;
+        const maxHz = window.receiverSpectrumMaxHz?.() ?? 30000000;
+        return (maxHz - minHz) / (this.defaultBinCount || this.binCount || 1024);
     }
 
     // Backend now handles dynamic bin count adjustment for deep zoom levels
@@ -5688,7 +5698,7 @@ class SpectrumDisplay {
         if (!this.connected || !this.ws) return;
 
         // Suppress edge detection during zoom transition to prevent
-        // unwanted retuning when tuned near 0 or 30 MHz edges
+        // unwanted retuning when tuned near receiver coverage edges
         this.skipEdgeDetectionTemporary = true;
         setTimeout(() => { this.skipEdgeDetectionTemporary = false; }, 1000);
 
@@ -5712,9 +5722,9 @@ class SpectrumDisplay {
         const newTotalBW = newBinBandwidth * this.binCount;
         const halfBandwidth = newTotalBW / 2;
 
-        // Constrain center frequency to keep view within 0-30 MHz
-        const minCenterFreq = 0 + halfBandwidth;
-        const maxCenterFreq = 30e6 - halfBandwidth;
+        // Constrain center frequency to configured receiver coverage.
+        const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+        const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
         newCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
 
         // Clear peak hold before zoom to prevent misalignment
@@ -5747,7 +5757,7 @@ class SpectrumDisplay {
         if (!this.connected || !this.ws) return;
 
         // Suppress edge detection during zoom transition to prevent
-        // unwanted retuning when tuned near 0 or 30 MHz edges
+        // unwanted retuning when tuned near receiver edges
         this.skipEdgeDetectionTemporary = true;
         setTimeout(() => { this.skipEdgeDetectionTemporary = false; }, 1000);
 
@@ -5781,9 +5791,9 @@ class SpectrumDisplay {
         const newTotalBW = newBinBandwidth * this.binCount;
         const halfBandwidth = newTotalBW / 2;
 
-        // Constrain center frequency to keep view within 0-30 MHz
-        const minCenterFreq = 0 + halfBandwidth;
-        const maxCenterFreq = 30e6 - halfBandwidth;
+        // Constrain center frequency to configured receiver coverage.
+        const minCenterFreq = (window.receiverMinFrequencyHz?.() ?? 10000) + halfBandwidth;
+        const maxCenterFreq = (window.receiverMaxFrequencyHz?.() ?? 30000000) - halfBandwidth;
         newCenterFreq = Math.max(minCenterFreq, Math.min(maxCenterFreq, newCenterFreq));
 
         // Clear peak hold before zoom to prevent misalignment
@@ -5811,7 +5821,7 @@ class SpectrumDisplay {
         }
     }
 
-    // Reset zoom to full view (0-30 MHz)
+    // Reset zoom to the receiver's default instantaneous view.
     resetZoom() {
         if (!this.connected || !this.ws) return;
 

--- a/user_spectrum_websocket.go
+++ b/user_spectrum_websocket.go
@@ -410,19 +410,18 @@ func (swsh *UserSpectrumWebSocketHandler) handleMessages(conn *wsConn, session *
 			newBinCount := session.BinCount
 
 			if msg.Frequency > 0 {
-				// Enforce center frequency within HF range (10 kHz – 30 MHz)
-				const minCenterFreq = 10000    // 10 kHz
-				const maxCenterFreq = 30000000 // 30 MHz
+				// Enforce center frequency within configured receiver coverage.
+				minCenterFreq, maxCenterFreq := swsh.sessions.config.FrequencyRange()
 				if msg.Frequency < minCenterFreq {
-					log.Printf("Rejecting spectrum update: center frequency %d Hz < minimum %d Hz (10 kHz)",
+					log.Printf("Rejecting spectrum update: center frequency %d Hz < minimum %d Hz",
 						msg.Frequency, minCenterFreq)
-					swsh.sendError(conn, "Center frequency must be at least 10 kHz")
+					swsh.sendError(conn, "Center frequency is below receiver coverage")
 					continue
 				}
 				if msg.Frequency > maxCenterFreq {
-					log.Printf("Rejecting spectrum update: center frequency %d Hz > maximum %d Hz (30 MHz)",
+					log.Printf("Rejecting spectrum update: center frequency %d Hz > maximum %d Hz",
 						msg.Frequency, maxCenterFreq)
-					swsh.sendError(conn, "Center frequency must be at most 30 MHz")
+					swsh.sendError(conn, "Center frequency is above receiver coverage")
 					continue
 				}
 				newFreq = msg.Frequency
@@ -493,7 +492,7 @@ func (swsh *UserSpectrumWebSocketHandler) handleMessages(conn *wsConn, session *
 			} else if newBinBW < 7500 {
 				safeBinBW = 5000
 			} else {
-				// For very large bin bandwidths (e.g., default 29296.875 for full 0-30 MHz),
+				// For very large bin bandwidths in a wide receiver view,
 				// don't round - pass through as-is for full bandwidth view
 				safeBinBW = newBinBW
 			}

--- a/websdr_scale.go
+++ b/websdr_scale.go
@@ -7,10 +7,10 @@ package main
 // set to e.scaleimgs[zoom][tileIndex].  Each tile is a 1024×14 PNG showing
 // frequency tick marks and labels for the portion of the band it covers.
 //
-// Tile geometry (band = 10 kHz … 30 MHz, i.e. 29 990 kHz wide):
+// Tile geometry is derived from Config.SpectrumRange:
 //
-//	tileWidthKHz[zoom] = 29990 / (1 << zoom)
-//	tileStartKHz       = 10 + tile * tileWidthKHz
+//	tileWidthKHz[zoom] = bandWidth / (1 << zoom)
+//	tileStartKHz       = bandStart + tile * tileWidthKHz
 //	pixelsPerKHz       = 1024 / tileWidthKHz
 //
 // Label step is chosen so that labels are at least ~60 px apart.
@@ -109,6 +109,7 @@ func formatFreqLabel(kHz float64) string {
 // niceSteps are candidate label spacings in kHz, from finest to coarsest.
 var niceSteps = []float64{
 	1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000, 10000,
+	20000, 50000, 100000, 200000, 500000, 1000000,
 }
 
 // chooseLabelStep picks the finest step that still places labels at least
@@ -129,10 +130,8 @@ func chooseLabelStep(pixelsPerKHz, minPxApart float64) float64 {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const (
-	scaleBandStartKHz = 10.0
-	scaleBandBWKHz    = 29990.0 // 30000 - 10
-	scaleImgW         = 1024
-	scaleImgH         = 14
+	scaleImgW = 1024
+	scaleImgH = 14
 )
 
 // handleScalePNG serves GET /~~scale?band=B&zoom=Z&tile=N
@@ -160,8 +159,11 @@ func (h *WebSDRHandler) handleScalePNG(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Tile frequency range.
-	tileWidthKHz := scaleBandBWKHz / float64(numTiles)
-	tileStartKHz := scaleBandStartKHz + float64(tile)*tileWidthKHz
+	minFrequency, maxFrequency := h.config.SpectrumRange()
+	bandStartKHz := float64(minFrequency) / 1000
+	bandWidthKHz := float64(maxFrequency-minFrequency) / 1000
+	tileWidthKHz := bandWidthKHz / float64(numTiles)
+	tileStartKHz := bandStartKHz + float64(tile)*tileWidthKHz
 	tileEndKHz := tileStartKHz + tileWidthKHz
 	pixelsPerKHz := float64(scaleImgW) / tileWidthKHz
 

--- a/websdr_websocket.go
+++ b/websdr_websocket.go
@@ -401,11 +401,16 @@ type websdrConn struct {
 }
 
 func newWebSDRConn(conn *websocket.Conn, handler *WebSDRHandler, clientIP string) *websdrConn {
+	defaultFrequency := handler.config.Admin.DefaultFrequency
+	minFrequency, maxFrequency := handler.config.SpectrumRange()
+	if defaultFrequency < minFrequency || defaultFrequency > maxFrequency {
+		defaultFrequency = minFrequency + (maxFrequency-minFrequency)/2
+	}
 	return &websdrConn{
 		conn:         conn,
 		handler:      handler,
 		clientIP:     clientIP,
-		tuneKHz:      14175.0,
+		tuneKHz:      float64(defaultFrequency) / 1000,
 		loKHz:        -3.0,
 		hiKHz:        -0.3,
 		mode:         0,
@@ -599,11 +604,12 @@ func (c *websdrConn) applyParamCommand(text string) {
 
 	if v := vals.Get("f"); v != "" {
 		newFreq, _ := strconv.ParseFloat(v, 64)
-		// Clamp to valid HF range: 10 kHz – 30 MHz
-		if newFreq < 10.0 {
-			newFreq = 10.0
-		} else if newFreq > 30000.0 {
-			newFreq = 30000.0
+		minHz, maxHz := c.handler.config.FrequencyRange()
+		minKHz, maxKHz := float64(minHz)/1000.0, float64(maxHz)/1000.0
+		if newFreq < minKHz {
+			newFreq = minKHz
+		} else if newFreq > maxKHz {
+			newFreq = maxKHz
 		}
 		if newFreq != c.tuneKHz {
 			c.tuneKHz = newFreq
@@ -818,7 +824,7 @@ func (c *websdrConn) applyWaterparamCommand(text string) {
 	// needs c.mu to drain SpectrumChan, and radiod blocks waiting for that
 	// drain before it can respond to the update).
 	//
-	// The hardcoded HF band is 10 kHz–30 MHz (bandwidth = 29990 kHz).
+	// The band is the receiver's configured instantaneous spectrum range.
 	// maxZoom is 8 (matching handleBandInfoJS), giving a maxzoom grid of
 	// 1024 × 2^8 = 262144 pixels spanning the full band.
 	//
@@ -839,9 +845,10 @@ func (c *websdrConn) applyWaterparamCommand(text string) {
 	// At zoom level z, the visible bandwidth is bandBW / 2^z.
 	// Center = visibleStart + visibleBW/2
 	// binBandwidth = visibleBW / binCount
-	const bandStartHz = 10000.0  // 10 kHz
-	const bandEndHz = 30000000.0 // 30 MHz
-	const bandBWHz = bandEndHz - bandStartHz
+	minFrequency, maxFrequency := c.handler.config.SpectrumRange()
+	bandStartHz := float64(minFrequency)
+	bandEndHz := float64(maxFrequency)
+	bandBWHz := bandEndHz - bandStartHz
 	const maxZoom = 8
 	const maxZoomPixels = 1024 * (1 << maxZoom) // 262144
 	const minBinBWHz = 500.0                    // radiod minimum bin bandwidth (Hz)
@@ -876,7 +883,7 @@ func (c *websdrConn) applyWaterparamCommand(text string) {
 	visibleStartHz := bandStartHz + startOffsetHz
 	centerHz := visibleStartHz + visibleBWHz/2.0
 
-	// Clamp center frequency to valid HF range (10 kHz – 30 MHz).
+	// Clamp center frequency to configured receiver coverage.
 	// A malformed or out-of-range start value from the client can produce
 	// a calculated center outside the band.  Clamp rather than reject so
 	// the waterfall stays usable at the boundary.
@@ -1094,9 +1101,10 @@ func (h *WebSDRHandler) handleWaterfallStream(w http.ResponseWriter, r *http.Req
 	// (zoom=0, start=0) so the waterfall shows data before the first
 	// /~~waterparam command arrives.
 	{
-		const bandStartHz = 10000.0
-		const bandEndHz = 30000000.0
-		const bandBWHz = bandEndHz - bandStartHz
+		minFrequency, maxFrequency := c.handler.config.SpectrumRange()
+		bandStartHz := float64(minFrequency)
+		bandEndHz := float64(maxFrequency)
+		bandBWHz := bandEndHz - bandStartHz
 		centerHz := bandStartHz + bandBWHz/2.0
 		binBandwidthHz := bandBWHz / float64(c.wfWidth)
 		_ = h.sessions.UpdateSpectrumSession(session.ID, uint64(centerHz), binBandwidthHz, c.wfWidth)
@@ -1924,8 +1932,10 @@ func (h *WebSDRHandler) buildOrgStatusBody() string {
 	qth := latLonToGridSquare(h.config.Admin.GPS.Lat, h.config.Admin.GPS.Lon)
 	fmt.Fprintln(&buf, "Qth: "+qth)
 
-	// Description: "0-30 MHz SDR[, <Callsign>][, <Location>]"
-	descParts := []string{"0-30 MHz SDR"}
+	minFrequency, maxFrequency := h.config.SpectrumRange()
+	rangeDescription := fmt.Sprintf("%.3f-%.3f MHz SDR",
+		float64(minFrequency)/1_000_000, float64(maxFrequency)/1_000_000)
+	descParts := []string{rangeDescription}
 	if h.config.Admin.Callsign != "" {
 		descParts = append(descParts, h.config.Admin.Callsign)
 	}
@@ -1963,13 +1973,15 @@ func (h *WebSDRHandler) buildOrgStatusBody() string {
 		}
 	}
 
-	// Fixed hardware band: 10 kHz – 30 MHz (UberSDR limitation)
+	// Advertise the coverage configured for the active receiver.
 	antenna := h.config.Admin.Antenna
 	if antenna == "" {
-		antenna = "HF"
+		antenna = "SDR"
 	}
+	centerKHz := float64(minFrequency+(maxFrequency-minFrequency)/2) / 1000
+	bandwidthKHz := float64(maxFrequency-minFrequency) / 1000
 	fmt.Fprintf(&buf, "Bands: 1\n")
-	fmt.Fprintf(&buf, "Band: 0 15005.000000 29990.000000 %s\n", antenna)
+	fmt.Fprintf(&buf, "Band: 0 %.6f %.6f %s\n", centerKHz, bandwidthKHz, antenna)
 
 	fmt.Fprintf(&buf, "Users: %d\n", users)
 
@@ -2069,7 +2081,7 @@ func (h *WebSDRHandler) websdrThroughputStats() (audioKBps, wfKBps, httpKBps flo
 }
 
 // websdrNormalizeFreq converts a tuning frequency in kHz to a normalized 0–1
-// fraction of the HF band (10 kHz – 30 MHz).  The WebSDR frontend's douu()
+// fraction of the configured spectrum band. The WebSDR frontend's douu()
 // function multiplies this by 1024 to get a pixel offset on the band display.
 func websdrNormalizeFreq(tuneKHz float64) float64 {
 	const bandStartKHz = 10.0
@@ -2303,7 +2315,7 @@ func (h *WebSDRHandler) handleLogbook(w http.ResponseWriter, r *http.Request) {
 // websdr-base.js reads this file on every page load to discover the available
 // bands (nbands, bandinfo[]), the current chseq, and the idle timeout.
 // The real WebSDR server generates this from its config at startup; we generate
-// it on-the-fly with a single hardcoded HF band (10 kHz–30 MHz).
+// it on-the-fly with the active receiver's configured coverage.
 //
 // Fields per band entry (all required by websdr-base.js):
 //   centerfreq   — centre of the band in kHz
@@ -2322,8 +2334,8 @@ func (h *WebSDRHandler) handleBandInfoJS(w http.ResponseWriter, r *http.Request)
 	noCacheHeaders(w)
 	w.Header().Set("Content-Type", "application/javascript")
 
-	// Single hardcoded HF band: 10 kHz–30 MHz.
-	bands := []Band{{Label: "HF", Start: 10000, End: 30000000}}
+	minFrequency, maxFrequency := h.config.SpectrumRange()
+	bands := []Band{{Label: h.config.Receiver.Driver, Start: minFrequency, End: maxFrequency}}
 
 	idleMS := 0
 	if h.config.Server.SessionTimeout > 0 {
@@ -2346,7 +2358,7 @@ func (h *WebSDRHandler) handleBandInfoJS(w http.ResponseWriter, r *http.Request)
 		if bwKHz <= 0 {
 			bwKHz = 192.0
 		}
-		centerKHz := 15005.0       // true centre of 10 kHz–30 MHz HF band (midpoint of 10–30000 kHz)
+		centerKHz := startKHz + bwKHz/2
 		vfoKHz := centerKHz + 10.0 // default VFO 10 kHz above centre
 
 		// tuningstep: 1/32 kHz (31.25 Hz), matching real WebSDR default

--- a/websocket.go
+++ b/websocket.go
@@ -486,12 +486,10 @@ func (wsh *WebSocketHandler) HandleWebSocket(w http.ResponseWriter, r *http.Requ
 	if freq := query.Get("frequency"); freq != "" {
 		var f uint64
 		if _, err := fmt.Sscanf(freq, "%d", &f); err == nil {
-			// Validate frequency range: 10 kHz to 30 MHz
-			const minFreq uint64 = 10000    // 10 kHz
-			const maxFreq uint64 = 30000000 // 30 MHz
-			if f < minFreq || f > maxFreq {
-				log.Printf("Rejected WebSocket connection: frequency %d Hz out of range (10 kHz - 30 MHz)", f)
-				wsh.sendError(conn, fmt.Sprintf("Frequency %d Hz is out of valid range (10 kHz - 30 MHz)", f))
+			minFreq, maxFreq := wsh.config.FrequencyRange()
+			if !wsh.config.IsFrequencySupported(f) {
+				log.Printf("Rejected WebSocket connection: frequency %d Hz out of configured range (%d-%d Hz)", f, minFreq, maxFreq)
+				wsh.sendError(conn, fmt.Sprintf("Frequency %d Hz is out of valid range (%d-%d Hz)", f, minFreq, maxFreq))
 				return
 			}
 			frequency = f
@@ -856,11 +854,9 @@ func (wsh *WebSocketHandler) handleMessages(conn *wsConn, sessionHolder *session
 			newBandwidthHigh := currentSession.BandwidthHigh
 
 			if msg.Frequency > 0 {
-				// Validate frequency range: 10 kHz to 30 MHz
-				const minFreq uint64 = 10000    // 10 kHz
-				const maxFreq uint64 = 30000000 // 30 MHz
-				if msg.Frequency < minFreq || msg.Frequency > maxFreq {
-					wsh.sendError(conn, fmt.Sprintf("Frequency %d Hz is out of valid range (10 kHz - 30 MHz)", msg.Frequency))
+				minFreq, maxFreq := wsh.config.FrequencyRange()
+				if !wsh.config.IsFrequencySupported(msg.Frequency) {
+					wsh.sendError(conn, fmt.Sprintf("Frequency %d Hz is out of valid range (%d-%d Hz)", msg.Frequency, minFreq, maxFreq))
 					continue // Non-fatal, keep connection open
 				}
 				newFreq = msg.Frequency


### PR DESCRIPTION
## Summary

- add a receiver/backend abstraction with KA9Q Radio profiles for RX-888, RTL-SDR, Airspy, Airspy HF+, SDRplay, HackRF, bladeRF, Fobos, FUNcube, and HydraSDR, plus an external KA9Q-compatible bridge path for SoapySDR/vendor/remote receivers
- make RF coverage and instantaneous bandwidth configuration-driven across sessions, spectrum, monitoring, native Web UI, KiwiSDR, and WebSDR compatibility layers
- add an extensible scheduled-decoder registry and document the shared-IQ service contract for ADS-B, UAT, AIS, rtl_433, ACARS/VDL2/HFDL, broadcast metadata, and satellite workflows
- add receive-only DSD-FME digital voice decoding for DMR, P25 Phase 1/2, NXDN, D-Star, YSF, M17, dPMR, ProVoice/EDACS, and X2-TDMA, including decoded audio, metadata, fixed safe profiles, and encrypted-audio suppression
- add multimon-ng paging/signalling decoding for POCSAG, FLEX, SAME/EAS, DTMF, two-tone families, and legacy telemetry
- bundle pinned DSD-FME/MBELib plus multimon-ng in the Docker image and add startup decoder availability checks
- add Web UI panels, example configuration, tests, and operator documentation

## Validation

- `go test -race ./audio_extensions/digitalvoice ./audio_extensions/signalling`
- JavaScript syntax checks for both new Web UI extensions
- JSON parsing for both extension manifests
- YAML parsing for `config.yaml.example`, `extensions.yaml.example`, and `docker-compose.yml`
- shell syntax checks for the entrypoint and decoder health-check scripts
- `git diff --check`
- earlier compile-only Linux validation of the application with an Opus shim

## Environment limitations

- A full native Windows `go test .` remains blocked by the existing Linux-only `syscall.Setpriority` use in soundmodem and the existing CGo/libopus requirement.
- Docker is not installed on the development workstation, so the final multi-stage image recipe has not been executed locally. The PR is intentionally draft until CI or a Docker-capable Linux host builds it and hardware-in-the-loop samples are exercised.
- Wide-IQ targets are documented behind a shared service-adapter contract; they are not represented as operational until dedicated tuner scheduling, sidecars, fixtures, UI, and hardware tests are added.

## Safety

Digital voice is receive-only. The browser API accepts no arbitrary decoder arguments, executables, privacy keys, or decryption keys. Encrypted-call metadata may be displayed, but audio is explicitly suppressed.
